### PR TITLE
chore: add CI gate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: npx vitest run
 
   # Integration tests require Go and the wspulse/core + wspulse/server repos
-  # as siblings. Only runs on pushes to main — this is the gate before tagging.
+  # as siblings. Runs on push to main/develop and PRs targeting main/develop.
   test-integration:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -119,10 +119,14 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     if: always()
-    needs: [test-integration]
+    needs: [lint-test, test-integration]
     steps:
       - name: Verify test-integration passed
         run: |
+          if [[ "${{ needs.lint-test.result }}" != "success" ]]; then
+            echo "lint-test failed — test-integration skipped is not valid"
+            exit 1
+          fi
           if [[ "${{ needs.test-integration.result }}" != "success" && "${{ needs.test-integration.result }}" != "skipped" ]]; then
             echo "test-integration failed"
             exit 1


### PR DESCRIPTION
Adds a check gate job that aggregates matrix results into a single status check. Enables consistent branch protection ruleset across all repos.