### PR TITLE
doc: add issue tracking workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,10 +84,9 @@ All new features and design changes follow this process — do not skip steps:
    6. If you are about to edit production code and no failing test exists yet — stop and go back to step 1.
 9. **STOP — before every commit, verify this checklist:**
    1. Run `make check` (fmt → lint → test) and confirm it passes. Skip if the commit contains only non-code changes (e.g. documentation, comments, Markdown).
-   2. Run GitHub Copilot code review (`github.copilot.chat.review.changes`) on the working-tree diff and resolve every comment before proceeding.
-   3. Commit message follows [commit-message-instructions.md](instructions/commit-message-instructions.md): correct type, subject ≤ 50 chars, numbered body items stating reason → change.
-   4. This commit contains exactly one logical change — no unrelated modifications.
-   5. If any item fails — fix it before committing.
+   2. Commit message follows [commit-message-instructions.md](instructions/commit-message-instructions.md): correct type, subject ≤ 50 chars, numbered body items stating reason → change.
+   3. This commit contains exactly one logical change — no unrelated modifications.
+   4. If any item fails — fix it before committing.
 10. **Accuracy** — if you have questions or need clarification, ask the user. Do not make assumptions without confirming.
 11. **Language consistency** — when the user writes in Traditional Chinese, respond in Traditional Chinese; otherwise respond in English.
 12. **Throw policy — fail early, never at steady-state runtime** — Enforce errors at the earliest possible phase:


### PR DESCRIPTION
## Summary

Add repo-scoped vs global issue tracking rules to Feature Workflow steps 5 and 7.

## Changes

- Step 5: repo-scoped issues stay on the source repo; cross-repo/global issues go to `wspulse/.github`
- Step 7: repo-scoped PRs link directly to the issue; global PRs mention the issue and comment on it with the PR link

## Checklist

- [x] Documentation-only change — no `make check` required
- [x] Commit message follows commit-message-instructions.md