### PR TITLE
docs: move onTransportDrop breaking change into v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## [Unreleased]
 
-### Changed
-
-- **BREAKING**: `onTransportDrop` callback signature changed from `(err: Error) => void` to `(err: Error | null) => void`. The callback now fires on clean `close()` calls with `err = null`, in addition to unexpected transport drops. When `close()` is called while reconnecting, the callback does not fire again.
-
 ---
 
 ## [0.5.0] - 2026-04-04
@@ -23,6 +19,7 @@
 
 ### Changed
 
+- **BREAKING**: `onTransportDrop` callback signature changed from `(err: Error) => void` to `(err: Error | null) => void`. The callback now fires on clean `close()` calls with `err = null`, in addition to unexpected transport drops. When `close()` is called while reconnecting, the callback does not fire again.
 - `test-integration` CI job removed; component tests run as part of `lint-test`
 
 ### Removed


### PR DESCRIPTION
## Summary

`[Unreleased]` had the `onTransportDrop` signature breaking change that belongs in v0.5.0. Moves it into the `### Changed` section of `[0.5.0]` and clears `[Unreleased]` so the release PR is complete.

## Changes

- Moved `onTransportDrop` breaking change entry from `[Unreleased]` to the top of `[0.5.0] ### Changed`
- Cleared the `[Unreleased]` section

## Checklist

- [x] CHANGELOG updated
- [x] No code changes — docs-only commit, `make check` not required