### PR TITLE
fix: discard send buffer on close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `close()` now discards unsent buffered frames instead of attempting a best-effort flush. Aligns with the behaviour contract: frames accepted by `send()` but not yet written to the transport are discarded on close.
+
 ---
 
 ## [0.5.1] - 2026-04-06

--- a/src/client.ts
+++ b/src/client.ts
@@ -697,11 +697,8 @@ class WspulseClient implements Client {
     this.stopDrain();
     this.stopHeartbeat();
 
-    // Best-effort flush: fire each pending frame with writeWait deadline.
-    // Results are intentionally not awaited — shutdown proceeds immediately.
-    while (this.sendBuffer.length > 0) {
-      void this.sendOneFrame(this.sendBuffer.shift() as string | Uint8Array);
-    }
+    // Discard unsent frames — close() does not drain the send buffer.
+    this.sendBuffer.length = 0;
 
     // Close the WebSocket. Suppress errors (may already be closed).
     try {

--- a/test/component/misc.test.ts
+++ b/test/component/misc.test.ts
@@ -197,6 +197,25 @@ describe("component: misc", () => {
     expect(f1.event).toBe("b");
   });
 
+  // close() discards unsent buffered frames (contract: close() does not drain)
+  it("close discards unsent buffered frames", async () => {
+    const clock = new FakeClock();
+    const t = new MockTransport();
+    const { client } = await connectMock(clock, {}, t);
+
+    // Buffer three frames — drain timer (5 ms) has not fired yet.
+    client.send({ event: "a" });
+    client.send({ event: "b" });
+    client.send({ event: "c" });
+
+    // Close immediately — before drain timer fires.
+    client.close();
+    await client.done;
+
+    // No frames should have been sent to the transport.
+    expect(t.sent.length).toBe(0);
+  });
+
   // Browser path: send() has no callback form, no timeout enforced
   it("browser transport sends without timeout", async () => {
     const clock = new FakeClock();


### PR DESCRIPTION
## Summary

Replace the best-effort flush loop in `shutdown()` with an explicit buffer discard, aligning with the behaviour contract that mandates `close()` discards unsent buffered frames.

## Related issues

Closes #26
Relates to wspulse/.github#30

## Changes

- Remove fire-and-forget flush loop in `shutdown()` (`while (sendBuffer.length > 0) { sendOneFrame(...) }`)
- Replace with `this.sendBuffer.length = 0` — immediate discard
- Add component test `close discards unsent buffered frames` that verifies no frames are sent to the transport after `close()`
- Add CHANGELOG entry under `[Unreleased]`

## Checklist

### Required

- [x] `make check` passes (format → lint → type-check → test)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Bug fix: includes a test that fails before the fix and passes after