### PR TITLE
chore: add pr-to-main-gate workflow

### DIFF
--- a/.github/workflows/pr-to-main-gate.yml
+++ b/.github/workflows/pr-to-main-gate.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   changelog-gate:
-    uses: wspulse/.github/.github/workflows/pr-to-main-gate.yml@main
+    uses: wspulse/.github/.github/workflows/changelog-gate.yml@main
 
   version-consistency:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add standalone `pr-to-main-gate.yml` that calls the reusable `changelog-gate.yml` workflow in `wspulse/.github`. Ensures any PR to main triggers the gate regardless of which files changed — no `paths-ignore` bypass possible.

## Changes

- `.github/workflows/pr-to-main-gate.yml`: thin wrapper calling `wspulse/.github/.github/workflows/changelog-gate.yml@main`

## Checklist

### Required

- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Workflow changes: tested on a feature branch before merging