### PR TITLE
refactor!: align heartbeat API with coder/websocket migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Changed (BREAKING)
+
+- **Heartbeat API flattened**: removed `HeartbeatOptions` interface and `heartbeat` option. Replaced by top-level `pingInterval` (was `heartbeat.pingPeriod`) and `writeTimeout` (was `writeWait`). Pong deadline is now implicit in `writeTimeout` (was separate `heartbeat.pongWait`).
+- Renamed `writeWait` option to `writeTimeout` for naming consistency across SDKs.
+- Validation error messages updated: `wspulse: heartbeat.pingPeriod ...` becomes `wspulse: pingInterval ...`; `wspulse: writeWait ...` becomes `wspulse: writeTimeout ...`.
+
+### Removed
+
+- `HeartbeatOptions` exported type.
+- `heartbeat.pongWait` option (pong deadline now uses `writeTimeout`).
+
 ---
 
 ## [0.5.2] - 2026-04-09

--- a/src/client.ts
+++ b/src/client.ts
@@ -538,8 +538,10 @@ class WspulseClient implements Client {
     this.pongHandlerWs = ws;
     ws.on("pong", this.pongHandler);
 
-    // Send an initial Ping immediately so the pong deadline starts from a real
-    // ping, not from connection open.
+    // Send an initial Ping so the pong deadline is anchored to an actual
+    // round-trip. Without this, the deadline starts counting from connection
+    // open — if pingInterval > writeTimeout the deadline would expire before
+    // the first periodic Ping fires.
     if (ws.readyState === WS_OPEN && typeof ws.ping === "function") {
       ws.ping();
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -502,8 +502,8 @@ class WspulseClient implements Client {
   /**
    * Start the heartbeat mechanism on a WebSocket.
    *
-   * Node.js (`ws` library): sends Ping frames every `pingPeriod` ms, and
-   * sets a pong deadline timer of `pongWait` ms that is reset on each Pong.
+   * Node.js (`ws` library): sends Ping frames every `pingInterval` ms, and
+   * sets a pong deadline timer of `writeTimeout` ms that is reset on each Pong.
    * If the deadline fires, the WebSocket is closed (triggering transport drop).
    *
    * Browser: Ping/Pong is handled automatically by the browser engine.
@@ -514,7 +514,7 @@ class WspulseClient implements Client {
     // Only meaningful when ws supports .on() and .ping() (Node.js ws lib).
     if (typeof ws.on !== "function" || typeof ws.ping !== "function") return;
 
-    const { pingPeriod, pongWait } = this.opts.heartbeat;
+    const { pingInterval, writeTimeout } = this.opts;
 
     // Reset (or start) the pong deadline timer.
     const resetPongDeadline = () => {
@@ -527,7 +527,7 @@ class WspulseClient implements Client {
         } else {
           ws.close(WS_CLOSE_GOING_AWAY, "pong timeout");
         }
-      }, pongWait);
+      }, writeTimeout);
     };
 
     // Listen for Pong frames to reset the deadline.
@@ -539,8 +539,7 @@ class WspulseClient implements Client {
     ws.on("pong", this.pongHandler);
 
     // Send an initial Ping immediately so the pong deadline starts from a real
-    // ping, not from connection open. This prevents false timeouts when
-    // pingPeriod > pongWait.
+    // ping, not from connection open.
     if (ws.readyState === WS_OPEN && typeof ws.ping === "function") {
       ws.ping();
     }
@@ -551,7 +550,7 @@ class WspulseClient implements Client {
       if (ws.readyState === WS_OPEN && typeof ws.ping === "function") {
         ws.ping();
       }
-    }, pingPeriod);
+    }, pingInterval);
   }
 
   /** Stop heartbeat timers (ping + pong deadline) and remove pong listener. */
@@ -584,7 +583,7 @@ class WspulseClient implements Client {
   /**
    * Flush all buffered frames to the WebSocket serially with per-write
    * timeout. On Node.js each frame is sent via `sendOneFrame` so a
-   * stalled socket is detected within `writeWait`. In browsers `send()`
+   * stalled socket is detected within `writeTimeout`. In browsers `send()`
    * is fire-and-forget (no completion callback) so no deadline applies.
    *
    * Stops draining if the socket is not open (reconnect will restart it).
@@ -620,7 +619,7 @@ class WspulseClient implements Client {
    * Send a single frame with write-deadline enforcement.
    *
    * On Node.js (`ws` library): uses the callback form of `send()` and
-   * races it against a `writeWait` timeout. On timeout the socket is
+   * races it against a `writeTimeout` timeout. On timeout the socket is
    * closed, which triggers `handleTransportDrop`.
    *
    * In browsers: `send()` is fire-and-forget; returns `true` immediately.
@@ -641,7 +640,7 @@ class WspulseClient implements Client {
       return Promise.resolve(true);
     }
 
-    // Node.js ws: race callback vs writeWait timeout.
+    // Node.js ws: race callback vs writeTimeout.
     return new Promise<boolean>((resolve) => {
       let settled = false;
       const timer = this.clock.setTimeout(() => {
@@ -653,7 +652,7 @@ class WspulseClient implements Client {
           // Already closed.
         }
         resolve(false);
-      }, this.opts.writeWait);
+      }, this.opts.writeTimeout);
       try {
         (
           ws.send as (d: string | Uint8Array, cb: (err?: Error) => void) => void

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,7 @@ export type { Client } from "./client.js";
 export type { Transport } from "./transport.js";
 export type { Codec } from "./codec.js";
 export { JSONCodec } from "./codec.js";
-export type {
-  ClientOptions,
-  AutoReconnectOptions,
-  HeartbeatOptions,
-} from "./options.js";
+export type { ClientOptions, AutoReconnectOptions } from "./options.js";
 export { connect } from "./client.js";
 export { backoff } from "./backoff.js";
 export {

--- a/src/options.ts
+++ b/src/options.ts
@@ -80,6 +80,9 @@ export interface ClientOptions {
    * Deadline for a single write operation, in milliseconds. Also used as the
    * pong deadline — if no Pong arrives within this duration after a Ping, the
    * connection is considered dead. Default: 10 000 (10 s). Must be in (0, 30 000].
+   *
+   * Setting this value below the expected server round-trip time will cause
+   * spurious heartbeat disconnects even when the server is healthy.
    */
   writeTimeout?: number;
   /** Max inbound message size in bytes. Default: 1 MiB (1 048 576). */

--- a/src/options.ts
+++ b/src/options.ts
@@ -22,23 +22,6 @@ export interface AutoReconnectOptions {
 }
 
 /**
- * Client-side heartbeat configuration.
- *
- * The client sends WebSocket Ping frames every `pingPeriod` ms.
- * If no Pong is received within `pongWait` ms, the connection is considered
- * dead and the transport is closed.
- *
- * Note: browser environments have no programmatic Ping/Pong API — heartbeat
- * monitoring is a no-op there; the browser engine handles keepalive internally.
- */
-export interface HeartbeatOptions {
-  /** Interval between client-sent Ping frames, in milliseconds. */
-  pingPeriod: number;
-  /** Pong deadline in milliseconds; connection closes if no Pong is received. */
-  pongWait: number;
-}
-
-/**
  * Options accepted by {@link connect}.
  *
  * All callbacks default to no-ops. Callbacks are invoked synchronously in
@@ -85,10 +68,20 @@ export interface ClientOptions {
   codec?: Codec;
   /** Enable exponential backoff reconnection. Disabled by default. */
   autoReconnect?: AutoReconnectOptions;
-  /** Heartbeat timing expectations. Defaults to 20 s ping / 60 s pong. */
-  heartbeat?: HeartbeatOptions;
-  /** Write deadline in milliseconds. Default: 10 000 (10 s). */
-  writeWait?: number;
+  /**
+   * Interval between client-sent Ping frames, in milliseconds.
+   * Default: 20 000 (20 s). Must be in (0, 60 000].
+   *
+   * Browser environments have no programmatic Ping/Pong API — heartbeat
+   * monitoring is a no-op there; the browser engine handles keepalive internally.
+   */
+  pingInterval?: number;
+  /**
+   * Deadline for a single write operation, in milliseconds. Also used as the
+   * pong deadline — if no Pong arrives within this duration after a Ping, the
+   * connection is considered dead. Default: 10 000 (10 s). Must be in (0, 30 000].
+   */
+  writeTimeout?: number;
   /** Max inbound message size in bytes. Default: 1 MiB (1 048 576). */
   maxMessageSize?: number;
   /**
@@ -128,14 +121,11 @@ export interface ClientOptions {
   _clock?: Clock;
 }
 
-/** @internal Default heartbeat timing: 20 s ping, 60 s pong. */
-const DEFAULT_HEARTBEAT: HeartbeatOptions = {
-  pingPeriod: 20_000,
-  pongWait: 60_000,
-};
+/** @internal Default ping interval: 20 seconds. */
+const DEFAULT_PING_INTERVAL = 20_000;
 
-/** @internal Default write deadline: 10 seconds. */
-const DEFAULT_WRITE_WAIT = 10_000;
+/** @internal Default write timeout: 10 seconds. */
+const DEFAULT_WRITE_TIMEOUT = 10_000;
 
 /** @internal Default max inbound message: 1 MiB. */
 const DEFAULT_MAX_MESSAGE_SIZE = 1 << 20;
@@ -147,9 +137,8 @@ const DEFAULT_SEND_BUFFER_SIZE = 256;
 const MAX_SEND_BUFFER_SIZE = 4096;
 
 /** @internal Upper bound constants for config validation. */
-const MAX_PING_PERIOD = 60_000;
-const MAX_PONG_WAIT = 120_000;
-const MAX_WRITE_WAIT = 30_000;
+const MAX_PING_INTERVAL = 60_000;
+const MAX_WRITE_TIMEOUT = 30_000;
 const MAX_MSG_SIZE_BYTES = 64 << 20;
 const MAX_BASE_DELAY = 60_000;
 const MAX_DELAY_LIMIT = 300_000;
@@ -168,8 +157,8 @@ export interface ResolvedOptions {
   onTransportDrop: (err: Error | null) => void;
   codec: Codec;
   autoReconnect: AutoReconnectOptions | undefined;
-  heartbeat: HeartbeatOptions;
-  writeWait: number;
+  pingInterval: number;
+  writeTimeout: number;
   maxMessageSize: number;
   dialHeaders: Record<string, string>;
   sendBufferSize: number;
@@ -199,45 +188,27 @@ function validateOptions(opts: ClientOptions): void {
     }
   }
 
-  if (opts.writeWait !== undefined) {
-    if (!Number.isFinite(opts.writeWait)) {
-      throw new Error("wspulse: writeWait must be a finite number");
+  if (opts.pingInterval !== undefined) {
+    if (!Number.isFinite(opts.pingInterval)) {
+      throw new Error("wspulse: pingInterval must be a finite number");
     }
-    if (opts.writeWait <= 0) {
-      throw new Error("wspulse: writeWait must be positive");
+    if (opts.pingInterval <= 0) {
+      throw new Error("wspulse: pingInterval must be positive");
     }
-    if (opts.writeWait > MAX_WRITE_WAIT) {
-      throw new Error("wspulse: writeWait exceeds maximum (30s)");
+    if (opts.pingInterval > MAX_PING_INTERVAL) {
+      throw new Error("wspulse: pingInterval exceeds maximum (1m)");
     }
   }
 
-  if (opts.heartbeat !== undefined) {
-    if (typeof opts.heartbeat !== "object" || opts.heartbeat === null) {
-      throw new Error("wspulse: heartbeat must be an object");
+  if (opts.writeTimeout !== undefined) {
+    if (!Number.isFinite(opts.writeTimeout)) {
+      throw new Error("wspulse: writeTimeout must be a finite number");
     }
-    const hb = opts.heartbeat;
-    if (!Number.isFinite(hb.pingPeriod)) {
-      throw new Error("wspulse: heartbeat.pingPeriod must be a finite number");
+    if (opts.writeTimeout <= 0) {
+      throw new Error("wspulse: writeTimeout must be positive");
     }
-    if (hb.pingPeriod <= 0) {
-      throw new Error("wspulse: heartbeat.pingPeriod must be positive");
-    }
-    if (hb.pingPeriod > MAX_PING_PERIOD) {
-      throw new Error("wspulse: heartbeat.pingPeriod exceeds maximum (1m)");
-    }
-    if (!Number.isFinite(hb.pongWait)) {
-      throw new Error("wspulse: heartbeat.pongWait must be a finite number");
-    }
-    if (hb.pongWait <= 0) {
-      throw new Error("wspulse: heartbeat.pongWait must be positive");
-    }
-    if (hb.pongWait > MAX_PONG_WAIT) {
-      throw new Error("wspulse: heartbeat.pongWait exceeds maximum (2m)");
-    }
-    if (hb.pingPeriod >= hb.pongWait) {
-      throw new Error(
-        "wspulse: heartbeat.pingPeriod must be strictly less than heartbeat.pongWait",
-      );
+    if (opts.writeTimeout > MAX_WRITE_TIMEOUT) {
+      throw new Error("wspulse: writeTimeout exceeds maximum (30s)");
     }
   }
 
@@ -311,8 +282,8 @@ export function resolveOptions(opts?: ClientOptions): ResolvedOptions {
     onTransportDrop: opts?.onTransportDrop ?? noop,
     codec: opts?.codec ?? JSONCodec,
     autoReconnect: opts?.autoReconnect,
-    heartbeat: opts?.heartbeat ?? { ...DEFAULT_HEARTBEAT },
-    writeWait: opts?.writeWait ?? DEFAULT_WRITE_WAIT,
+    pingInterval: opts?.pingInterval ?? DEFAULT_PING_INTERVAL,
+    writeTimeout: opts?.writeTimeout ?? DEFAULT_WRITE_TIMEOUT,
     maxMessageSize: opts?.maxMessageSize ?? DEFAULT_MAX_MESSAGE_SIZE,
     dialHeaders: opts?.dialHeaders ?? {},
     sendBufferSize: opts?.sendBufferSize ?? DEFAULT_SEND_BUFFER_SIZE,

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -417,7 +417,8 @@ describe("heartbeat (pong timeout)", () => {
     let disconnectErr: Error | null | undefined;
 
     testClient = await connect(`ws://127.0.0.1:${addr.port}`, {
-      heartbeat: { pingPeriod: 30, pongWait: 80 },
+      pingInterval: 30,
+      writeTimeout: 80,
       onTransportDrop: () => {
         transportDropped = true;
       },
@@ -426,7 +427,7 @@ describe("heartbeat (pong timeout)", () => {
       },
     });
 
-    // Wait for pong timeout to fire (pongWait = 80ms).
+    // Wait for pong timeout to fire (writeTimeout = 80ms).
     await testClient.done;
 
     expect(transportDropped).toBe(true);

--- a/test/component/misc.test.ts
+++ b/test/component/misc.test.ts
@@ -98,8 +98,8 @@ describe("component: misc", () => {
     }).toThrow(SendBufferFullError);
   });
 
-  // Write timeout: stalled socket triggers onTransportDrop within writeWait
-  it("stalled socket triggers onTransportDrop within writeWait", async () => {
+  // Write timeout: stalled socket triggers onTransportDrop within writeTimeout
+  it("stalled socket triggers onTransportDrop within writeTimeout", async () => {
     const clock = new FakeClock();
     let dropErr: Error | null | undefined;
     let dropResolve: () => void = () => {};
@@ -114,7 +114,7 @@ describe("component: misc", () => {
     const { client } = await connectMock(
       clock,
       {
-        writeWait: 100,
+        writeTimeout: 100,
         onTransportDrop(err) {
           dropErr = err;
           dropResolve();
@@ -129,7 +129,7 @@ describe("component: misc", () => {
     // Advance past the drain timer (5 ms) so flushSendBuffer fires.
     await clock.advance(10);
 
-    // The send is now stalled. Advance past writeWait (100 ms) to trigger timeout.
+    // The send is now stalled. Advance past writeTimeout (100 ms) to trigger timeout.
     await clock.advance(100);
     await dropped;
 
@@ -160,7 +160,7 @@ describe("component: misc", () => {
 
     const dialer = new MockDialer([t1, t2]);
     const client = await connect("ws://mock/ws", {
-      writeWait: 100,
+      writeTimeout: 100,
       autoReconnect: { maxRetries: 3, baseDelay: 10, maxDelay: 50 },
       onMessage(frame) {
         received.push(frame);
@@ -180,7 +180,7 @@ describe("component: misc", () => {
     // Advance past drain timer (5 ms) → flush starts → stalls.
     await clock.advance(10);
 
-    // Advance past writeWait (100 ms) → timeout → transport drop → reconnect.
+    // Advance past writeTimeout (100 ms) → timeout → transport drop → reconnect.
     // Then advance past backoff delay to let reconnect succeed.
     await clock.advance(200);
     await restored;
@@ -228,7 +228,7 @@ describe("component: misc", () => {
 
     const dialer = new MockDialer([t]);
     const client = await connect("ws://mock/ws", {
-      writeWait: 100,
+      writeTimeout: 100,
       _dialer: dialer.dial,
       _clock: clock,
     });
@@ -265,7 +265,8 @@ describe("component: misc", () => {
           disconnectErr = err;
           disconnectResolve();
         },
-        heartbeat: { pingPeriod: 50, pongWait: 150 },
+        pingInterval: 50,
+        writeTimeout: 150,
       },
       t,
     );

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -55,7 +55,7 @@ describe("connect", () => {
 
   it("rejects with options when server is unreachable", async () => {
     await expect(
-      connect("ws://127.0.0.1:19999", { writeWait: 5000 }),
+      connect("ws://127.0.0.1:19999", { writeTimeout: 5000 }),
     ).rejects.toThrow("wspulse: dial failed");
   });
 });

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -119,6 +119,18 @@ describe("resolveOptions validation", () => {
     );
   });
 
+  it("throws on NaN pingInterval", () => {
+    expect(() => resolveOptions({ pingInterval: NaN })).toThrow(
+      "wspulse: pingInterval must be a finite number",
+    );
+  });
+
+  it("throws on Infinity pingInterval", () => {
+    expect(() => resolveOptions({ pingInterval: Infinity })).toThrow(
+      "wspulse: pingInterval must be a finite number",
+    );
+  });
+
   // writeTimeout
   it("throws on zero writeTimeout", () => {
     expect(() => resolveOptions({ writeTimeout: 0 })).toThrow(
@@ -135,6 +147,18 @@ describe("resolveOptions validation", () => {
   it("throws when writeTimeout exceeds 30s", () => {
     expect(() => resolveOptions({ writeTimeout: 31_000 })).toThrow(
       "wspulse: writeTimeout exceeds maximum (30s)",
+    );
+  });
+
+  it("throws on NaN writeTimeout", () => {
+    expect(() => resolveOptions({ writeTimeout: NaN })).toThrow(
+      "wspulse: writeTimeout must be a finite number",
+    );
+  });
+
+  it("throws on Infinity writeTimeout", () => {
+    expect(() => resolveOptions({ writeTimeout: Infinity })).toThrow(
+      "wspulse: writeTimeout must be a finite number",
     );
   });
 

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -7,9 +7,8 @@ describe("resolveOptions", () => {
   it("returns defaults when no options provided", () => {
     const opts = resolveOptions();
     expect(opts.maxMessageSize).toBe(1 << 20);
-    expect(opts.writeWait).toBe(10_000);
-    expect(opts.heartbeat.pingPeriod).toBe(20_000);
-    expect(opts.heartbeat.pongWait).toBe(60_000);
+    expect(opts.writeTimeout).toBe(10_000);
+    expect(opts.pingInterval).toBe(20_000);
     expect(opts.autoReconnect).toBeUndefined();
     expect(opts.dialHeaders).toEqual({});
     expect(opts.codec).toBe(JSONCodec);
@@ -19,12 +18,12 @@ describe("resolveOptions", () => {
   it("preserves user-provided values", () => {
     const opts = resolveOptions({
       maxMessageSize: 2048,
-      writeWait: 5000,
+      writeTimeout: 5000,
       autoReconnect: { maxRetries: 3, baseDelay: 100, maxDelay: 5000 },
       dialHeaders: { Authorization: "Bearer token" },
     });
     expect(opts.maxMessageSize).toBe(2048);
-    expect(opts.writeWait).toBe(5000);
+    expect(opts.writeTimeout).toBe(5000);
     expect(opts.autoReconnect?.maxRetries).toBe(3);
     expect(opts.dialHeaders.Authorization).toBe("Bearer token");
   });
@@ -70,18 +69,15 @@ describe("resolveOptions", () => {
     expect(onTransportDrop).toHaveBeenCalledWith(err);
   });
 
-  it("preserves custom heartbeat values", () => {
-    const opts = resolveOptions({
-      heartbeat: { pingPeriod: 10_000, pongWait: 30_000 },
-    });
-    expect(opts.heartbeat.pingPeriod).toBe(10_000);
-    expect(opts.heartbeat.pongWait).toBe(30_000);
+  it("preserves custom pingInterval", () => {
+    const opts = resolveOptions({ pingInterval: 10_000 });
+    expect(opts.pingInterval).toBe(10_000);
   });
 
   it("handles empty options object", () => {
     const opts = resolveOptions({});
     expect(opts.maxMessageSize).toBe(1 << 20);
-    expect(opts.writeWait).toBe(10_000);
+    expect(opts.writeTimeout).toBe(10_000);
     expect(opts.autoReconnect).toBeUndefined();
   });
 });
@@ -104,65 +100,41 @@ describe("resolveOptions validation", () => {
     expect(() => resolveOptions({ maxMessageSize: 0 })).not.toThrow();
   });
 
-  // writeWait
-  it("throws on zero writeWait", () => {
-    expect(() => resolveOptions({ writeWait: 0 })).toThrow(
-      "wspulse: writeWait must be positive",
+  // pingInterval
+  it("throws on zero pingInterval", () => {
+    expect(() => resolveOptions({ pingInterval: 0 })).toThrow(
+      "wspulse: pingInterval must be positive",
     );
   });
 
-  it("throws on negative writeWait", () => {
-    expect(() => resolveOptions({ writeWait: -1 })).toThrow(
-      "wspulse: writeWait must be positive",
+  it("throws on negative pingInterval", () => {
+    expect(() => resolveOptions({ pingInterval: -1 })).toThrow(
+      "wspulse: pingInterval must be positive",
     );
   });
 
-  it("throws when writeWait exceeds 30s", () => {
-    expect(() => resolveOptions({ writeWait: 31_000 })).toThrow(
-      "wspulse: writeWait exceeds maximum (30s)",
+  it("throws when pingInterval exceeds 1m", () => {
+    expect(() => resolveOptions({ pingInterval: 61_000 })).toThrow(
+      "wspulse: pingInterval exceeds maximum (1m)",
     );
   });
 
-  // heartbeat.pingPeriod
-  it("throws on zero pingPeriod", () => {
-    expect(() =>
-      resolveOptions({ heartbeat: { pingPeriod: 0, pongWait: 60_000 } }),
-    ).toThrow("wspulse: heartbeat.pingPeriod must be positive");
-  });
-
-  it("throws when pingPeriod exceeds 1m", () => {
-    expect(() =>
-      resolveOptions({ heartbeat: { pingPeriod: 61_000, pongWait: 120_000 } }),
-    ).toThrow("wspulse: heartbeat.pingPeriod exceeds maximum (1m)");
-  });
-
-  // heartbeat.pongWait
-  it("throws on zero pongWait", () => {
-    expect(() =>
-      resolveOptions({ heartbeat: { pingPeriod: 1_000, pongWait: 0 } }),
-    ).toThrow("wspulse: heartbeat.pongWait must be positive");
-  });
-
-  it("throws when pongWait exceeds 2m", () => {
-    expect(() =>
-      resolveOptions({ heartbeat: { pingPeriod: 1_000, pongWait: 121_000 } }),
-    ).toThrow("wspulse: heartbeat.pongWait exceeds maximum (2m)");
-  });
-
-  // heartbeat: pingPeriod < pongWait
-  it("throws when pingPeriod equals pongWait", () => {
-    expect(() =>
-      resolveOptions({ heartbeat: { pingPeriod: 30_000, pongWait: 30_000 } }),
-    ).toThrow(
-      "wspulse: heartbeat.pingPeriod must be strictly less than heartbeat.pongWait",
+  // writeTimeout
+  it("throws on zero writeTimeout", () => {
+    expect(() => resolveOptions({ writeTimeout: 0 })).toThrow(
+      "wspulse: writeTimeout must be positive",
     );
   });
 
-  it("throws when pingPeriod exceeds pongWait", () => {
-    expect(() =>
-      resolveOptions({ heartbeat: { pingPeriod: 60_000, pongWait: 20_000 } }),
-    ).toThrow(
-      "wspulse: heartbeat.pingPeriod must be strictly less than heartbeat.pongWait",
+  it("throws on negative writeTimeout", () => {
+    expect(() => resolveOptions({ writeTimeout: -1 })).toThrow(
+      "wspulse: writeTimeout must be positive",
+    );
+  });
+
+  it("throws when writeTimeout exceeds 30s", () => {
+    expect(() => resolveOptions({ writeTimeout: 31_000 })).toThrow(
+      "wspulse: writeTimeout exceeds maximum (30s)",
     );
   });
 
@@ -280,8 +252,8 @@ describe("resolveOptions validation", () => {
     expect(() =>
       resolveOptions({
         maxMessageSize: 64 << 20,
-        writeWait: 30_000,
-        heartbeat: { pingPeriod: 60_000, pongWait: 120_000 },
+        pingInterval: 60_000,
+        writeTimeout: 30_000,
         autoReconnect: {
           maxRetries: 32,
           baseDelay: 60_000,


### PR DESCRIPTION
## Summary

Flatten heartbeat configuration API to match client-go v0.6.0: remove compound `HeartbeatOptions`, replace with top-level `pingInterval` + `writeTimeout`.

## Related issues

Closes #35
Relates to wspulse/.github#32

## Changes

- Removed `HeartbeatOptions` interface and `heartbeat` compound option from `ClientOptions`
- Added top-level `pingInterval` option (was `heartbeat.pingPeriod`)
- Renamed `writeWait` to `writeTimeout`; pong deadline now uses `writeTimeout` (was separate `heartbeat.pongWait`)
- Removed `HeartbeatOptions` from public exports (`index.ts`)
- Updated validation rules and error messages (`wspulse: heartbeat.pingPeriod ...` → `wspulse: pingInterval ...`)
- Removed `pingPeriod < pongWait` cross-field validation constraint
- Added NaN/Infinity validation tests for `pingInterval` and `writeTimeout`
- Added RTT caveat to `writeTimeout` JSDoc
- Updated CHANGELOG with breaking changes

## Checklist

### Required

- [x] `make check` passes (format → lint → type-check → test)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Breaking change: major version bump discussed in linked issue (v0, acceptable)