### PR TITLE
feat: remove client-side ping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Removed
 
 - **BREAKING**: `HeartbeatOptions` interface and `ClientOptions.heartbeat` option — client-side ping is removed; dead-connection detection is now handled exclusively by the Hub's server-side heartbeat.
+- **BREAKING**: Removed optional `ping?()` from the exported `Transport` interface — no longer needed without client-side heartbeat.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Removed
+
+- **BREAKING**: `HeartbeatOptions` interface and `ClientOptions.heartbeat` option — client-side ping is removed; dead-connection detection is now handled exclusively by the Hub's server-side heartbeat.
+
 ---
 
 ## [0.5.2] - 2026-04-09

--- a/README.md
+++ b/README.md
@@ -195,7 +195,6 @@ try {
 - **Transport drop callback** — `onTransportDrop` fires on every transport death (with the error) and on a clean `close()` call (with `null`). Fires exactly once per transport lifecycle. Useful for metrics and logging.
 - **Transport restore callback** — `onTransportRestore` fires after a successful reconnect (not on the initial connect). Useful for re-subscribing or refreshing state.
 - **Permanent disconnect callback** — `onDisconnect` fires exactly once when the client is truly done (`close()` called, retries exhausted, or connection lost without auto-reconnect).
-- **Heartbeat** — Client-side Ping/Pong keeps the connection alive and detects silently-dead servers. Node.js only (browsers handle Ping/Pong automatically at the protocol level).
 - **Max message size** — Inbound messages exceeding `maxMessageSize` are rejected with close code 1009.
 - **Backpressure** — bounded 256-frame send buffer; throws `SendBufferFullError` when full.
 - **`done` Promise** — resolves when the client reaches CLOSED state. Await it to block until permanently disconnected.
@@ -208,7 +207,6 @@ try {
 | --------------------- | ----------------------------------- | -------------------------------------------- |
 | WebSocket transport   | `ws` package (peer dep)             | Native `WebSocket` API                       |
 | `dialHeaders`         | ✅ Passed as HTTP headers           | ⚠️ Silently ignored (browser API limitation) |
-| Heartbeat (Ping/Pong) | ✅ Client sends Ping, monitors Pong | ⚠️ No-op (browser handles automatically)     |
 | `maxMessageSize`      | ✅                                  | ✅                                           |
 | Auto-reconnect        | ✅                                  | ✅                                           |
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ const client = await connect(url, {
 | `onTransportDrop`    | `(err: Error \| null) => void`        | no-op             |
 | `autoReconnect`      | `{ maxRetries, baseDelay, maxDelay }` | disabled          |
 | `codec`              | `Codec`                               | `JSONCodec`       |
-| `heartbeat`          | `{ pingPeriod, pongWait }` (ms)       | 20 000 / 60 000   |
 | `writeWait`          | `number` (ms)                         | 10 000            |
 | `maxMessageSize`     | `number` (bytes)                      | 1 MiB (1 048 576) |
 | `dialHeaders`        | `Record<string, string>`              | `{}`              |

--- a/doc/component-tests.md
+++ b/doc/component-tests.md
@@ -38,7 +38,7 @@ reliably as part of `make check` (via `npx vitest run`).
 | `onTransportRestore does not fire on initial connect` | Restore callback reserved for reconnect only |
 | `passes URL with query params to dialer`              | URL forwarding to dialer function            |
 
-**Total: 18 component tests** (7 scenarios + 11 additional; scenario 7 is N/A as a dedicated scenario — covered by `concurrent sends do not race` in Additional Tests).
+**Coverage rows: 18** (7 scenarios + 11 additional). This is the count of documented coverage rows, not the full `it(...)` test count under `test/component/`. Scenario 7 is N/A as a dedicated scenario — covered by `concurrent sends do not race` in Additional Tests.
 
 ## Legacy Integration Tests
 

--- a/doc/component-tests.md
+++ b/doc/component-tests.md
@@ -19,9 +19,8 @@ reliably as part of `make check` (via `npx vitest run`).
 | 4   | Max retries exhausted -> `onDisconnect(RetriesExhaustedError)`     | `fires RetriesExhaustedError after max retries exhausted`              |
 | 5   | `close()` during reconnect -> loop stops, `onDisconnect(null)`     | `close() during reconnect fires onDisconnect(null)`                    |
 | 6   | `send()` on closed client -> `ConnectionClosedError`               | `send after close throws ConnectionClosedError`                        |
-| 7   | Heartbeat pong timeout -> `ConnectionLostError`                    | `pong timeout triggers ConnectionLostError`                            |
-| 8   | Concurrent sends: no data race or interleaving                     | N/A -- single-threaded JS (see Additional Tests)                       |
-| 9   | Concurrent `close()` + transport drop -> onDisconnect exactly once | `close() racing with transport drop fires onDisconnect exactly once`   |
+| 7   | Concurrent sends: no data race or interleaving                     | N/A -- single-threaded JS (see Additional Tests)                       |
+| 8   | Concurrent `close()` + transport drop -> onDisconnect exactly once | `close() racing with transport drop fires onDisconnect exactly once`   |
 
 ## Additional Tests
 
@@ -39,7 +38,7 @@ reliably as part of `make check` (via `npx vitest run`).
 | `onTransportRestore does not fire on initial connect` | Restore callback reserved for reconnect only |
 | `passes URL with query params to dialer`              | URL forwarding to dialer function            |
 
-**Total: 19 component tests** (8 scenarios + 11 additional; scenario 8 N/A -> moved to additional).
+**Total: 18 component tests** (7 scenarios + 11 additional; scenario 7 N/A -> moved to additional).
 
 ## Legacy Integration Tests
 

--- a/doc/component-tests.md
+++ b/doc/component-tests.md
@@ -29,7 +29,7 @@ reliably as part of `make check` (via `npx vitest run`).
 | `round-trips all Frame fields (event, payload)`       | Full Frame field fidelity through codec      |
 | `handles dial failure gracefully`                     | Dialer error rejects connect() Promise       |
 | `sends multiple frames and receives them in order`    | Message ordering preservation                |
-| `concurrent sends do not race`                        | 50 senders x 5 messages each (scenario 8)    |
+| `concurrent sends do not race`                        | 50 senders x 5 messages each (scenario 7)    |
 | `detects server-initiated close`                      | Transport close -> `onDisconnect(Error)`     |
 | `onDisconnect fires exactly once on close`            | User-initiated close -> single callback      |
 | `close is idempotent`                                 | Multiple `close()` calls -> single callback  |
@@ -38,7 +38,7 @@ reliably as part of `make check` (via `npx vitest run`).
 | `onTransportRestore does not fire on initial connect` | Restore callback reserved for reconnect only |
 | `passes URL with query params to dialer`              | URL forwarding to dialer function            |
 
-**Total: 18 component tests** (7 scenarios + 11 additional; scenario 7 N/A -> moved to additional).
+**Total: 18 component tests** (7 scenarios + 11 additional; scenario 7 is N/A as a dedicated scenario — covered by `concurrent sends do not race` in Additional Tests).
 
 ## Legacy Integration Tests
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -213,18 +213,6 @@ class WspulseClient implements Client {
   /** Whether a transport drop is being handled. Suppresses onTransportDrop(null) during shutdown. */
   private reconnecting = false;
 
-  /** Pong deadline timer — fires when server stops responding. */
-  private pongDeadlineTimer: ReturnType<typeof setTimeout> | null = null;
-
-  /** Ping interval timer — sends WebSocket Ping frames (Node.js only). */
-  private pingTimer: ReturnType<typeof setInterval> | null = null;
-
-  /** Stored pong handler reference for cleanup (prevents listener leak on reconnect). */
-  private pongHandler: (() => void) | null = null;
-
-  /** WebSocket instance the pong handler is attached to (for removeListener). */
-  private pongHandlerWs: Transport | null = null;
-
   /** Timer clock — replaced in tests for deterministic behaviour. @internal */
   private readonly clock: Clock;
 
@@ -249,7 +237,6 @@ class WspulseClient implements Client {
     }
 
     this.attachListeners(ws);
-    this.startHeartbeat(ws);
   }
 
   /**
@@ -363,7 +350,6 @@ class WspulseClient implements Client {
     if (this.closed) return;
 
     this.stopDrain();
-    this.stopHeartbeat();
     const dropErr = new Error("wspulse: transport closed unexpectedly");
     // Set reconnecting before firing the callback so that a synchronous
     // close() call inside onTransportDrop sees the correct state regardless
@@ -428,14 +414,13 @@ class WspulseClient implements Client {
         return;
       }
 
-      // Swap connection and restart listeners + drain + heartbeat.
+      // Swap connection and restart listeners + drain.
       this.ws = newWs;
       if (this.opts.codec.binaryType === "binary") {
         (newWs as unknown as { binaryType: string }).binaryType = "arraybuffer";
       }
       this.attachListeners(newWs);
       this.startDrain();
-      this.startHeartbeat(newWs);
 
       // Fire onTransportRestore outside the dial try/catch so a throwing
       // callback does not get misinterpreted as a dial failure.
@@ -494,90 +479,6 @@ class WspulseClient implements Client {
     if (this.drainTimer !== null) {
       this.clock.clearTimeout(this.drainTimer);
       this.drainTimer = null;
-    }
-  }
-
-  // ── heartbeat ───────────────────────────────────────────────────────────
-
-  /**
-   * Start the heartbeat mechanism on a WebSocket.
-   *
-   * Node.js (`ws` library): sends Ping frames every `pingPeriod` ms, and
-   * sets a pong deadline timer of `pongWait` ms that is reset on each Pong.
-   * If the deadline fires, the WebSocket is closed (triggering transport drop).
-   *
-   * Browser: Ping/Pong is handled automatically by the browser engine.
-   * There is no programmatic access to ping/pong frames, so heartbeat
-   * monitoring is a no-op in browser environments.
-   */
-  private startHeartbeat(ws: Transport): void {
-    // Only meaningful when ws supports .on() and .ping() (Node.js ws lib).
-    if (typeof ws.on !== "function" || typeof ws.ping !== "function") return;
-
-    const { pingPeriod, pongWait } = this.opts.heartbeat;
-
-    // Reset (or start) the pong deadline timer.
-    const resetPongDeadline = () => {
-      this.clearPongDeadline();
-      this.pongDeadlineTimer = this.clock.setTimeout(() => {
-        // Server failed to respond — forcefully destroy the socket so the
-        // close event fires immediately without waiting for a close handshake.
-        if (typeof ws.terminate === "function") {
-          ws.terminate();
-        } else {
-          ws.close(WS_CLOSE_GOING_AWAY, "pong timeout");
-        }
-      }, pongWait);
-    };
-
-    // Listen for Pong frames to reset the deadline.
-    // Store the handler so it can be removed in stopHeartbeat().
-    this.pongHandler = () => {
-      resetPongDeadline();
-    };
-    this.pongHandlerWs = ws;
-    ws.on("pong", this.pongHandler);
-
-    // Send an initial Ping immediately so the pong deadline starts from a real
-    // ping, not from connection open. This prevents false timeouts when
-    // pingPeriod > pongWait.
-    if (ws.readyState === WS_OPEN && typeof ws.ping === "function") {
-      ws.ping();
-    }
-    resetPongDeadline();
-
-    // Periodically send Ping frames.
-    this.pingTimer = this.clock.setInterval(() => {
-      if (ws.readyState === WS_OPEN && typeof ws.ping === "function") {
-        ws.ping();
-      }
-    }, pingPeriod);
-  }
-
-  /** Stop heartbeat timers (ping + pong deadline) and remove pong listener. */
-  private stopHeartbeat(): void {
-    this.clearPongDeadline();
-    if (this.pingTimer !== null) {
-      this.clock.clearInterval(this.pingTimer);
-      this.pingTimer = null;
-    }
-    // Remove pong listener from the previous WebSocket to prevent leaks.
-    if (
-      this.pongHandler !== null &&
-      this.pongHandlerWs !== null &&
-      typeof this.pongHandlerWs.removeListener === "function"
-    ) {
-      this.pongHandlerWs.removeListener("pong", this.pongHandler);
-    }
-    this.pongHandler = null;
-    this.pongHandlerWs = null;
-  }
-
-  /** Clear the pong deadline timer only. */
-  private clearPongDeadline(): void {
-    if (this.pongDeadlineTimer !== null) {
-      this.clock.clearTimeout(this.pongDeadlineTimer);
-      this.pongDeadlineTimer = null;
     }
   }
 
@@ -701,9 +602,8 @@ class WspulseClient implements Client {
     // Cancel any pending reconnect backoff delay.
     this.abortController.abort();
 
-    // Stop the drain timer and heartbeat.
+    // Stop the drain timer.
     this.stopDrain();
-    this.stopHeartbeat();
 
     // Discard unsent frames — close() does not drain the send buffer.
     this.sendBuffer.clear();

--- a/src/clock.ts
+++ b/src/clock.ts
@@ -6,14 +6,10 @@
 export interface Clock {
   setTimeout(fn: () => void, ms: number): ReturnType<typeof setTimeout>;
   clearTimeout(id: ReturnType<typeof setTimeout>): void;
-  setInterval(fn: () => void, ms: number): ReturnType<typeof setInterval>;
-  clearInterval(id: ReturnType<typeof setInterval>): void;
 }
 
 /** @internal Default clock backed by the global timer functions. */
 export const defaultClock: Clock = {
   setTimeout,
   clearTimeout,
-  setInterval,
-  clearInterval,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,7 @@ export type { Client } from "./client.js";
 export type { Transport } from "./transport.js";
 export type { Codec } from "./codec.js";
 export { JSONCodec } from "./codec.js";
-export type {
-  ClientOptions,
-  AutoReconnectOptions,
-  HeartbeatOptions,
-} from "./options.js";
+export type { ClientOptions, AutoReconnectOptions } from "./options.js";
 export { connect } from "./client.js";
 export { backoff } from "./backoff.js";
 export {

--- a/src/options.ts
+++ b/src/options.ts
@@ -22,23 +22,6 @@ export interface AutoReconnectOptions {
 }
 
 /**
- * Client-side heartbeat configuration.
- *
- * The client sends WebSocket Ping frames every `pingPeriod` ms.
- * If no Pong is received within `pongWait` ms, the connection is considered
- * dead and the transport is closed.
- *
- * Note: browser environments have no programmatic Ping/Pong API — heartbeat
- * monitoring is a no-op there; the browser engine handles keepalive internally.
- */
-export interface HeartbeatOptions {
-  /** Interval between client-sent Ping frames, in milliseconds. */
-  pingPeriod: number;
-  /** Pong deadline in milliseconds; connection closes if no Pong is received. */
-  pongWait: number;
-}
-
-/**
  * Options accepted by {@link connect}.
  *
  * All callbacks default to no-ops. Callbacks are invoked synchronously in
@@ -85,8 +68,6 @@ export interface ClientOptions {
   codec?: Codec;
   /** Enable exponential backoff reconnection. Disabled by default. */
   autoReconnect?: AutoReconnectOptions;
-  /** Heartbeat timing expectations. Defaults to 20 s ping / 60 s pong. */
-  heartbeat?: HeartbeatOptions;
   /** Write deadline in milliseconds. Default: 10 000 (10 s). */
   writeWait?: number;
   /** Max inbound message size in bytes. Default: 1 MiB (1 048 576). */
@@ -121,18 +102,12 @@ export interface ClientOptions {
   /**
    * Custom timer clock for testing.
    *
-   * @internal Test-only. When provided, all `setTimeout`/`setInterval` calls
-   * in the client are routed through this clock instead of the global timer
-   * functions. The default (`undefined`) falls back to {@link defaultClock}.
+   * @internal Test-only. When provided, all `setTimeout` calls in the client
+   * are routed through this clock instead of the global timer functions.
+   * The default (`undefined`) falls back to {@link defaultClock}.
    */
   _clock?: Clock;
 }
-
-/** @internal Default heartbeat timing: 20 s ping, 60 s pong. */
-const DEFAULT_HEARTBEAT: HeartbeatOptions = {
-  pingPeriod: 20_000,
-  pongWait: 60_000,
-};
 
 /** @internal Default write deadline: 10 seconds. */
 const DEFAULT_WRITE_WAIT = 10_000;
@@ -147,8 +122,6 @@ const DEFAULT_SEND_BUFFER_SIZE = 256;
 const MAX_SEND_BUFFER_SIZE = 4096;
 
 /** @internal Upper bound constants for config validation. */
-const MAX_PING_PERIOD = 60_000;
-const MAX_PONG_WAIT = 120_000;
 const MAX_WRITE_WAIT = 30_000;
 const MAX_MSG_SIZE_BYTES = 64 << 20;
 const MAX_BASE_DELAY = 60_000;
@@ -168,7 +141,6 @@ export interface ResolvedOptions {
   onTransportDrop: (err: Error | null) => void;
   codec: Codec;
   autoReconnect: AutoReconnectOptions | undefined;
-  heartbeat: HeartbeatOptions;
   writeWait: number;
   maxMessageSize: number;
   dialHeaders: Record<string, string>;
@@ -208,36 +180,6 @@ function validateOptions(opts: ClientOptions): void {
     }
     if (opts.writeWait > MAX_WRITE_WAIT) {
       throw new Error("wspulse: writeWait exceeds maximum (30s)");
-    }
-  }
-
-  if (opts.heartbeat !== undefined) {
-    if (typeof opts.heartbeat !== "object" || opts.heartbeat === null) {
-      throw new Error("wspulse: heartbeat must be an object");
-    }
-    const hb = opts.heartbeat;
-    if (!Number.isFinite(hb.pingPeriod)) {
-      throw new Error("wspulse: heartbeat.pingPeriod must be a finite number");
-    }
-    if (hb.pingPeriod <= 0) {
-      throw new Error("wspulse: heartbeat.pingPeriod must be positive");
-    }
-    if (hb.pingPeriod > MAX_PING_PERIOD) {
-      throw new Error("wspulse: heartbeat.pingPeriod exceeds maximum (1m)");
-    }
-    if (!Number.isFinite(hb.pongWait)) {
-      throw new Error("wspulse: heartbeat.pongWait must be a finite number");
-    }
-    if (hb.pongWait <= 0) {
-      throw new Error("wspulse: heartbeat.pongWait must be positive");
-    }
-    if (hb.pongWait > MAX_PONG_WAIT) {
-      throw new Error("wspulse: heartbeat.pongWait exceeds maximum (2m)");
-    }
-    if (hb.pingPeriod >= hb.pongWait) {
-      throw new Error(
-        "wspulse: heartbeat.pingPeriod must be strictly less than heartbeat.pongWait",
-      );
     }
   }
 
@@ -311,7 +253,6 @@ export function resolveOptions(opts?: ClientOptions): ResolvedOptions {
     onTransportDrop: opts?.onTransportDrop ?? noop,
     codec: opts?.codec ?? JSONCodec,
     autoReconnect: opts?.autoReconnect,
-    heartbeat: opts?.heartbeat ?? { ...DEFAULT_HEARTBEAT },
     writeWait: opts?.writeWait ?? DEFAULT_WRITE_WAIT,
     maxMessageSize: opts?.maxMessageSize ?? DEFAULT_MAX_MESSAGE_SIZE,
     dialHeaders: opts?.dialHeaders ?? {},

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -15,12 +15,10 @@ export interface Transport {
   onopen: ((ev: unknown) => void) | null;
   send(data: string | ArrayBuffer | Uint8Array | Blob): void;
   close(code?: number, reason?: string): void;
-  /** Node.js `ws` library: register event listener (ping, pong, etc.). */
+  /** Node.js `ws` library: register event listener. */
   on?(event: string, listener: (...args: unknown[]) => void): void;
   /** Node.js `ws` library: remove event listener. */
   removeListener?(event: string, listener: (...args: unknown[]) => void): void;
-  /** Node.js `ws` library: send a WebSocket Ping frame. */
-  ping?(data?: unknown, mask?: boolean, cb?: (err?: Error) => void): void;
   /** Node.js `ws` library: forcefully destroy the socket without close handshake. */
   terminate?(): void;
 }

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -401,39 +401,6 @@ describe("maxMessageSize", () => {
   });
 });
 
-describe("heartbeat (pong timeout)", () => {
-  it("closes connection when server stops responding to pings", async () => {
-    // Create a server that swallows pong responses.
-    const server = new WebSocketServer({ port: 0 });
-    server.on("connection", (ws) => {
-      // Prevent server from auto-replying to client pings by overriding pong.
-      ws.pong = () => {};
-    });
-    const addr = server.address();
-    if (typeof addr === "string" || addr === null) throw new Error("bad addr");
-    testServer = server;
-
-    let transportDropped = false;
-    let disconnectErr: Error | null | undefined;
-
-    testClient = await connect(`ws://127.0.0.1:${addr.port}`, {
-      heartbeat: { pingPeriod: 30, pongWait: 80 },
-      onTransportDrop: () => {
-        transportDropped = true;
-      },
-      onDisconnect: (err) => {
-        disconnectErr = err;
-      },
-    });
-
-    // Wait for pong timeout to fire (pongWait = 80ms).
-    await testClient.done;
-
-    expect(transportDropped).toBe(true);
-    expect(disconnectErr).toBeDefined();
-  });
-});
-
 describe("decode failure", () => {
   it("logs warning and continues processing valid frames", async () => {
     // Server that sends an invalid frame followed by a valid one.

--- a/test/component/fake-clock.ts
+++ b/test/component/fake-clock.ts
@@ -57,7 +57,8 @@ export class FakeClock implements Clock {
 
       this._now = nextDeadline;
 
-      // Collect all timers at this deadline.
+      // Collect all timers due at or before now (<= is defensive; equivalent
+      // to === here because _now is set to the earliest pending deadline).
       const toFire = this._timers.filter((t) => t.deadline <= this._now);
 
       // Remove fired timers.

--- a/test/component/fake-clock.ts
+++ b/test/component/fake-clock.ts
@@ -64,7 +64,7 @@ export class FakeClock implements Clock {
       this._timers = this._timers.filter((t) => t.deadline > this._now);
 
       // Fire callbacks. A prior callback may clear a later timer at the same
-      // deadline via clearTimeout/clearInterval — skip it if its ID was cleared.
+      // deadline via clearTimeout — skip it if its ID was cleared.
       this._clearedIds.clear();
       for (const t of toFire) {
         if (this._clearedIds.has(t.id)) continue;

--- a/test/component/fake-clock.ts
+++ b/test/component/fake-clock.ts
@@ -2,7 +2,7 @@
  * FakeClock — deterministic timer implementation for component tests.
  *
  * Implements the {@link Clock} interface. Timers registered via
- * `setTimeout`/`setInterval` never fire automatically. Tests control
+ * `setTimeout` never fire automatically. Tests control
  * virtual time by calling `await advance(ms)`, which fires all callbacks
  * whose deadline falls within the advanced window (in deadline order) and
  * flushes the microtask queue after each firing so awaited Promises
@@ -38,7 +38,7 @@ export class FakeClock implements Clock {
    * Advance virtual time by `ms` milliseconds.
    *
    * Fires all registered callbacks whose deadline falls within the window,
-   * in deadline order. Intervals are rescheduled after firing. If a callback
+   * in deadline order. If a callback
    * clears another timer at the same deadline, the cleared timer is skipped.
    * After each batch, the microtask queue is flushed so that awaited Promises
    * propagate correctly before the next timer fires.

--- a/test/component/fake-clock.ts
+++ b/test/component/fake-clock.ts
@@ -14,8 +14,6 @@ interface TimerEntry {
   id: number;
   deadline: number;
   fn: () => void;
-  type: "timeout" | "interval";
-  interval?: number;
 }
 
 export class FakeClock implements Clock {
@@ -26,34 +24,11 @@ export class FakeClock implements Clock {
 
   setTimeout(fn: () => void, ms: number): ReturnType<typeof setTimeout> {
     const id = this._nextId++;
-    this._timers.push({
-      id,
-      deadline: this._now + ms,
-      fn,
-      type: "timeout",
-    });
+    this._timers.push({ id, deadline: this._now + ms, fn });
     return id as unknown as ReturnType<typeof setTimeout>;
   }
 
   clearTimeout(handle: ReturnType<typeof setTimeout>): void {
-    const id = handle as unknown as number;
-    this._timers = this._timers.filter((t) => t.id !== id);
-    this._clearedIds.add(id);
-  }
-
-  setInterval(fn: () => void, ms: number): ReturnType<typeof setInterval> {
-    const id = this._nextId++;
-    this._timers.push({
-      id,
-      deadline: this._now + ms,
-      fn,
-      type: "interval",
-      interval: ms,
-    });
-    return id as unknown as ReturnType<typeof setInterval>;
-  }
-
-  clearInterval(handle: ReturnType<typeof setInterval>): void {
     const id = handle as unknown as number;
     this._timers = this._timers.filter((t) => t.id !== id);
     this._clearedIds.add(id);
@@ -85,19 +60,8 @@ export class FakeClock implements Clock {
       // Collect all timers at this deadline.
       const toFire = this._timers.filter((t) => t.deadline <= this._now);
 
-      // Rebuild timer list: remove timeouts, reschedule intervals.
-      const remaining: TimerEntry[] = [];
-      for (const t of this._timers) {
-        if (t.deadline <= this._now) {
-          if (t.type === "interval" && t.interval !== undefined) {
-            remaining.push({ ...t, deadline: this._now + t.interval });
-          }
-          // timeout: drop it
-        } else {
-          remaining.push(t);
-        }
-      }
-      this._timers = remaining;
+      // Remove fired timers.
+      this._timers = this._timers.filter((t) => t.deadline > this._now);
 
       // Fire callbacks. A prior callback may clear a later timer at the same
       // deadline via clearTimeout/clearInterval — skip it if its ID was cleared.

--- a/test/component/misc.test.ts
+++ b/test/component/misc.test.ts
@@ -1,11 +1,11 @@
 /**
- * Component tests — miscellaneous (concurrency, buffer, heartbeat).
+ * Component tests — miscellaneous (concurrency, buffer, write timeout).
  */
 import { describe, it, expect, afterEach } from "vitest";
 import { connect } from "../../src/client.js";
 import type { Client } from "../../src/client.js";
 import type { Frame } from "../../src/frame.js";
-import { ConnectionLostError, SendBufferFullError } from "../../src/errors.js";
+import { SendBufferFullError } from "../../src/errors.js";
 import { MockTransport, MockDialer } from "./mock-transport.js";
 import { FakeClock } from "./fake-clock.js";
 
@@ -243,41 +243,5 @@ describe("component: misc", () => {
     expect(t.sent.length).toBe(1);
     const f = JSON.parse(t.sent[0] as string) as Frame;
     expect(f.event).toBe("browser-msg");
-  });
-
-  // Scenario 7: Pong timeout -> ConnectionLostError
-  it("pong timeout triggers ConnectionLostError", async () => {
-    let disconnectErr: Error | null | undefined;
-    let disconnectResolve: () => void = () => {};
-    const disconnected = new Promise<void>((r) => {
-      disconnectResolve = r;
-    });
-    const clock = new FakeClock();
-
-    const t = new MockTransport();
-    // Stop responding to pings so the pong deadline fires.
-    t.suppressPongs();
-
-    const { client } = await connectMock(
-      clock,
-      {
-        onDisconnect(err) {
-          disconnectErr = err;
-          disconnectResolve();
-        },
-        heartbeat: { pingPeriod: 50, pongWait: 150 },
-      },
-      t,
-    );
-
-    // Advance past the pong deadline (150 ms) to trigger ConnectionLostError.
-    await clock.advance(200);
-    await disconnected;
-
-    expect(disconnectErr).toBeInstanceOf(ConnectionLostError);
-
-    // Prevent afterEach from double-closing.
-    testClient = null;
-    void client;
   });
 });

--- a/test/component/mock-transport.ts
+++ b/test/component/mock-transport.ts
@@ -32,9 +32,6 @@ export class MockTransport implements Transport {
   /** Event listeners registered via `on()` (Node.js ws-style). */
   private eventListeners = new Map<string, Set<(...args: unknown[]) => void>>();
 
-  /** When true, `ping()` does not trigger pong handlers. */
-  private pongsDisabled = false;
-
   /** When true, `send()` callback is never called (simulates stalled socket). */
   private sendsStalled = false;
 
@@ -76,16 +73,6 @@ export class MockTransport implements Transport {
     this.eventListeners.get(event)?.delete(listener);
   }
 
-  ping(_data?: unknown, _mask?: boolean, cb?: (err?: Error) => void): void {
-    cb?.();
-    if (!this.pongsDisabled) {
-      // Simulate pong arriving after a microtask (network round-trip).
-      queueMicrotask(() => {
-        this.eventListeners.get("pong")?.forEach((h) => h());
-      });
-    }
-  }
-
   terminate(): void {
     this.close(1001, "terminated");
   }
@@ -106,11 +93,6 @@ export class MockTransport implements Transport {
   /** Simulate a transport error. */
   injectError(): void {
     this.onerror?.({});
-  }
-
-  /** Stop responding to pings (simulates pong timeout). */
-  suppressPongs(): void {
-    this.pongsDisabled = true;
   }
 
   /** Stall all future sends — callback is never invoked (simulates blocked socket). */

--- a/test/component/mock-transport.ts
+++ b/test/component/mock-transport.ts
@@ -15,8 +15,8 @@ const WS_CLOSED = 3;
  * Mock transport that satisfies the {@link Transport} interface.
  *
  * Test code drives behaviour via `injectMessage()`, `injectClose()`,
- * `injectError()`, and `suppressPongs()`. Sent data is captured in
- * the `sent` array for assertions.
+ * and `injectError()`. Sent data is captured in the `sent` array
+ * for assertions.
  */
 export class MockTransport implements Transport {
   readyState: number = WS_OPEN;

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -8,8 +8,6 @@ describe("resolveOptions", () => {
     const opts = resolveOptions();
     expect(opts.maxMessageSize).toBe(1 << 20);
     expect(opts.writeWait).toBe(10_000);
-    expect(opts.heartbeat.pingPeriod).toBe(20_000);
-    expect(opts.heartbeat.pongWait).toBe(60_000);
     expect(opts.autoReconnect).toBeUndefined();
     expect(opts.dialHeaders).toEqual({});
     expect(opts.codec).toBe(JSONCodec);
@@ -70,14 +68,6 @@ describe("resolveOptions", () => {
     expect(onTransportDrop).toHaveBeenCalledWith(err);
   });
 
-  it("preserves custom heartbeat values", () => {
-    const opts = resolveOptions({
-      heartbeat: { pingPeriod: 10_000, pongWait: 30_000 },
-    });
-    expect(opts.heartbeat.pingPeriod).toBe(10_000);
-    expect(opts.heartbeat.pongWait).toBe(30_000);
-  });
-
   it("handles empty options object", () => {
     const opts = resolveOptions({});
     expect(opts.maxMessageSize).toBe(1 << 20);
@@ -120,49 +110,6 @@ describe("resolveOptions validation", () => {
   it("throws when writeWait exceeds 30s", () => {
     expect(() => resolveOptions({ writeWait: 31_000 })).toThrow(
       "wspulse: writeWait exceeds maximum (30s)",
-    );
-  });
-
-  // heartbeat.pingPeriod
-  it("throws on zero pingPeriod", () => {
-    expect(() =>
-      resolveOptions({ heartbeat: { pingPeriod: 0, pongWait: 60_000 } }),
-    ).toThrow("wspulse: heartbeat.pingPeriod must be positive");
-  });
-
-  it("throws when pingPeriod exceeds 1m", () => {
-    expect(() =>
-      resolveOptions({ heartbeat: { pingPeriod: 61_000, pongWait: 120_000 } }),
-    ).toThrow("wspulse: heartbeat.pingPeriod exceeds maximum (1m)");
-  });
-
-  // heartbeat.pongWait
-  it("throws on zero pongWait", () => {
-    expect(() =>
-      resolveOptions({ heartbeat: { pingPeriod: 1_000, pongWait: 0 } }),
-    ).toThrow("wspulse: heartbeat.pongWait must be positive");
-  });
-
-  it("throws when pongWait exceeds 2m", () => {
-    expect(() =>
-      resolveOptions({ heartbeat: { pingPeriod: 1_000, pongWait: 121_000 } }),
-    ).toThrow("wspulse: heartbeat.pongWait exceeds maximum (2m)");
-  });
-
-  // heartbeat: pingPeriod < pongWait
-  it("throws when pingPeriod equals pongWait", () => {
-    expect(() =>
-      resolveOptions({ heartbeat: { pingPeriod: 30_000, pongWait: 30_000 } }),
-    ).toThrow(
-      "wspulse: heartbeat.pingPeriod must be strictly less than heartbeat.pongWait",
-    );
-  });
-
-  it("throws when pingPeriod exceeds pongWait", () => {
-    expect(() =>
-      resolveOptions({ heartbeat: { pingPeriod: 60_000, pongWait: 20_000 } }),
-    ).toThrow(
-      "wspulse: heartbeat.pingPeriod must be strictly less than heartbeat.pongWait",
     );
   });
 
@@ -281,7 +228,6 @@ describe("resolveOptions validation", () => {
       resolveOptions({
         maxMessageSize: 64 << 20,
         writeWait: 30_000,
-        heartbeat: { pingPeriod: 60_000, pongWait: 120_000 },
         autoReconnect: {
           maxRetries: 32,
           baseDelay: 60_000,


### PR DESCRIPTION
## Summary

Remove redundant client-side heartbeat mechanism (ping loop + pong deadline tracking). Dead-connection detection now relies entirely on the Hub's server-side heartbeat, matching the standard pattern used by every major WebSocket framework.

## Related issues

Closes #39
Relates to wspulse/.github#39

## Changes

- Remove exported `HeartbeatOptions` interface and `ClientOptions.heartbeat` field (breaking)
- Remove internal `startHeartbeat()`, `stopHeartbeat()`, `clearPongDeadline()` methods and 4 private fields
- Remove `setInterval`/`clearInterval` from `Clock` interface (only heartbeat used them)
- Remove `ping?()` from `Transport` interface (dead after heartbeat removal)
- Simplify `FakeClock` — remove interval rescheduling infrastructure
- Clean up `MockTransport` — remove `ping()`, `suppressPongs()`, `pongsDisabled`
- Delete 9 heartbeat-related tests across 3 test files (125 tests remain, all passing)
- Update README options table, component-tests.md scenario matrix
- Add CHANGELOG entry under `[Unreleased]`

## Checklist

### Required

- [x] `make check` passes (format → lint → type-check → test)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Breaking change: major version bump discussed in linked issue