### PR TITLE
refactor: rename Frame to Message

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ wspulse/client-ts is a **WebSocket client library for TypeScript/JavaScript** wi
 - **`src/transport.ts`** — `Transport` interface (minimal WebSocket shape). Extracted so tests can provide mock implementations via `_dialer`.
 - **`src/options.ts`** — `ClientOptions` interface and `resolveOptions()` to merge with defaults.
 - **`src/codec.ts`** — `Codec` interface and `JSONCodec` default implementation. Mirrors Go `core` module's `Codec`.
-- **`src/frame.ts`** — `Frame` interface (event, payload — all optional).
+- **`src/message.ts`** — `Message` interface (event, payload — all optional).
 - **`src/errors.ts`** — Error classes: `ConnectionClosedError`, `RetriesExhaustedError`, `ConnectionLostError`.
 - **`src/backoff.ts`** — `backoff()` function for exponential delay with equal jitter (matches Go implementation).
 - **`src/index.ts`** — Public re-exports.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ making any changes.
 
 - `src/client.ts` — `connect()` entry point, `WspulseClient` implementation
 - `src/options.ts` — `ClientOptions` interface, `resolveOptions()` defaults
-- `src/frame.ts` — `Frame` interface
+- `src/message.ts` — `Message` interface
 - `src/errors.ts` — `ConnectionClosedError`, `RetriesExhaustedError`, `ConnectionLostError`
 - `src/backoff.ts` — `backoff()` exponential delay function
 - `src/index.ts` — public re-exports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `Frame` interface renamed to `Message`. Aligns with upstream `wspulse/core` rename — "frame" is reserved for the WebSocket protocol layer (RFC 6455); "message" is the correct term for the application-layer type.
+- **BREAKING**: `src/frame.ts` renamed to `src/message.ts`. Import paths updated accordingly.
+- All JSDoc, README, and internal references updated from "frame" to "message" (application layer) while preserving "WebSocket frame" where it refers to the wire protocol.
+
 ## [0.6.0] - 2026-04-16
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Works in **Node.js 20+** (via [`ws`](https://github.com/websockets/ws)) and **br
 ## Design Goals
 
 - Thin client: connect, send, receive, auto-reconnect
-- Matches server-side `Frame` wire format via JSON text frames
+- Matches server-side `Message` wire format via JSON text WebSocket frames
 - Exponential backoff with configurable retries (equal jitter)
 - Transport drop vs. permanent disconnect callbacks
 - Node.js and browser support from a single package
@@ -49,8 +49,8 @@ npm install ws
 import { connect } from "@wspulse/client-ts";
 
 const client = await connect("ws://localhost:8080/ws?room=r1&token=xyz", {
-  onMessage(frame) {
-    console.log(`[${frame.event}]`, frame.payload);
+  onMessage(msg) {
+    console.log(`[${msg.event}]`, msg.payload);
   },
   autoReconnect: {
     maxRetries: 5,
@@ -72,8 +72,8 @@ await client.done;
   import { connect } from "@wspulse/client-ts";
 
   const client = await connect("wss://api.example.com/ws?room=lobby", {
-    onMessage(frame) {
-      console.log(frame.event, frame.payload);
+    onMessage(msg) {
+      console.log(msg.event, msg.payload);
     },
   });
 
@@ -85,9 +85,9 @@ await client.done;
 
 ---
 
-## Frame Format
+## Message Format
 
-The default `JSONCodec` encodes frames as JSON text frames:
+The default `JSONCodec` encodes messages as JSON text WebSocket frames:
 
 ```json
 {
@@ -99,14 +99,14 @@ The default `JSONCodec` encodes frames as JSON text frames:
 To use a custom wire format (e.g. Protocol Buffers), implement the `Codec` interface:
 
 ```ts
-import type { Codec, Frame } from "@wspulse/client-ts";
+import type { Codec, Message } from "@wspulse/client-ts";
 
 const myCodec: Codec = {
   binaryType: "binary",
-  encode(frame: Frame): Uint8Array {
+  encode(msg: Message): Uint8Array {
     // serialize to binary
   },
-  decode(data: string | Uint8Array): Frame {
+  decode(data: string | Uint8Array): Message {
     // deserialize from binary
   },
 };
@@ -114,19 +114,19 @@ const myCodec: Codec = {
 const client = await connect(url, { codec: myCodec });
 ```
 
-The `event` field is the routing key on the server side. Set `frame.event` to match the handler registered with `r.On("chat.message", ...)` on the server. The `payload` field carries arbitrary data — the codec determines how it is serialized.
+The `event` field is the routing key on the server side. Set `msg.event` to match the handler registered with `r.On("chat.message", ...)` on the server. The `payload` field carries arbitrary data — the codec determines how it is serialized.
 
 ```ts
-// Send a typed frame — server routes by "event"
+// Send a typed message — server routes by "event"
 client.send({
   event: "chat.message",
   payload: { text: "hello world" },
 });
 
-// Receive typed frames
+// Receive typed messages
 const client = await connect(url, {
-  onMessage(frame) {
-    switch (frame.event) {
+  onMessage(msg) {
+    switch (msg.event) {
       case "chat.message":
         // handle message
         break;
@@ -146,7 +146,7 @@ const client = await connect(url, {
 | ----------------------- | ----------------------------------------------- |
 | `Client`                | Interface: `send()`, `close()`, `done`          |
 | `connect(url, opts?)`   | Connect and return a `Client`                   |
-| `Frame`                 | Interface: `{ event?, payload? }`               |
+| `Message`               | Interface: `{ event?, payload? }`               |
 | `Codec`                 | Interface: `encode()`, `decode()`, `binaryType` |
 | `JSONCodec`             | Default codec — JSON text frames                |
 | `ClientOptions`         | Options object type                             |
@@ -159,7 +159,7 @@ const client = await connect(url, {
 
 | Option               | Type                                  | Default           |
 | -------------------- | ------------------------------------- | ----------------- |
-| `onMessage`          | `(frame: Frame) => void`              | no-op             |
+| `onMessage`          | `(msg: Message) => void`              | no-op             |
 | `onDisconnect`       | `(err: Error \| null) => void`        | no-op             |
 | `onTransportRestore` | `() => void`                          | no-op             |
 | `onTransportDrop`    | `(err: Error \| null) => void`        | no-op             |
@@ -173,7 +173,7 @@ const client = await connect(url, {
 
 ## Logging
 
-The client logs warnings via `console.warn` when an inbound frame cannot be decoded by the configured codec. This is always enabled.
+The client logs warnings via `console.warn` when an inbound message cannot be decoded by the configured codec. This is always enabled.
 
 **Disable logging** by temporarily overriding `console.warn`:
 
@@ -196,7 +196,7 @@ try {
 - **Transport restore callback** — `onTransportRestore` fires after a successful reconnect (not on the initial connect). Useful for re-subscribing or refreshing state.
 - **Permanent disconnect callback** — `onDisconnect` fires exactly once when the client is truly done (`close()` called, retries exhausted, or connection lost without auto-reconnect).
 - **Max message size** — Inbound messages exceeding `maxMessageSize` are rejected with close code 1009.
-- **Backpressure** — bounded 256-frame send buffer; throws `SendBufferFullError` when full.
+- **Backpressure** — bounded 256-message send buffer; throws `SendBufferFullError` when full.
 - **`done` Promise** — resolves when the client reaches CLOSED state. Await it to block until permanently disconnected.
 
 ---

--- a/doc/component-tests.md
+++ b/doc/component-tests.md
@@ -13,7 +13,7 @@ reliably as part of `make check` (via `npx vitest run`).
 
 | #   | Scenario                                                           | Test Name                                                              |
 | --- | ------------------------------------------------------------------ | ---------------------------------------------------------------------- |
-| 1   | Connect -> send -> echo -> close clean                             | `connects, sends a frame, receives echo, and closes cleanly`           |
+| 1   | Connect -> send -> echo -> close clean                             | `connects, sends a message, receives echo, and closes cleanly`         |
 | 2   | Server drops -> onTransportDrop + onDisconnect (no reconnect)      | `server drop fires onTransportDrop and onDisconnect without reconnect` |
 | 3   | Auto-reconnect: server drops -> reconnects within maxRetries       | `reconnects after transport drop and resumes sending`                  |
 | 4   | Max retries exhausted -> `onDisconnect(RetriesExhaustedError)`     | `fires RetriesExhaustedError after max retries exhausted`              |
@@ -26,7 +26,7 @@ reliably as part of `make check` (via `npx vitest run`).
 
 | Test Name                                             | What It Covers                               |
 | ----------------------------------------------------- | -------------------------------------------- |
-| `round-trips all Frame fields (event, payload)`       | Full Frame field fidelity through codec      |
+| `round-trips all Message fields (event, payload)`     | Full Message field fidelity through codec    |
 | `handles dial failure gracefully`                     | Dialer error rejects connect() Promise       |
 | `sends multiple frames and receives them in order`    | Message ordering preservation                |
 | `concurrent sends do not race`                        | 50 senders x 5 messages each (scenario 7)    |

--- a/doc/component-tests.md
+++ b/doc/component-tests.md
@@ -28,7 +28,7 @@ reliably as part of `make check` (via `npx vitest run`).
 | ----------------------------------------------------- | -------------------------------------------- |
 | `round-trips all Message fields (event, payload)`     | Full Message field fidelity through codec    |
 | `handles dial failure gracefully`                     | Dialer error rejects connect() Promise       |
-| `sends multiple frames and receives them in order`    | Message ordering preservation                |
+| `sends multiple messages and receives them in order`  | Message ordering preservation                |
 | `concurrent sends do not race`                        | 50 senders x 5 messages each (scenario 7)    |
 | `detects server-initiated close`                      | Transport close -> `onDisconnect(Error)`     |
 | `onDisconnect fires exactly once on close`            | User-initiated close -> single callback      |

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,5 @@
 import type { Clock } from "./clock.js";
-import type { Frame } from "./frame.js";
+import type { Message } from "./message.js";
 import type { Transport } from "./transport.js";
 import type { ClientOptions, ResolvedOptions } from "./options.js";
 import { resolveOptions } from "./options.js";
@@ -20,14 +20,14 @@ import { backoff } from "./backoff.js";
  */
 export interface Client {
   /**
-   * Enqueue a Frame for delivery.
+   * Enqueue a Message for delivery.
    *
    * Non-blocking.
    *
    * @throws {@link ConnectionClosedError} if the client is in CLOSED state.
    * @throws {@link SendBufferFullError} if the internal send buffer is full.
    */
-  send(frame: Frame): void;
+  send(msg: Message): void;
 
   /**
    * Permanently terminate the connection and stop any reconnect loop.
@@ -240,16 +240,16 @@ class WspulseClient implements Client {
   }
 
   /**
-   * Enqueue a Frame for delivery.
+   * Enqueue a Message for delivery.
    *
    * @throws {@link ConnectionClosedError} if the client is in CLOSED state.
    * @throws {@link SendBufferFullError} if the internal send buffer is full.
    */
-  send(frame: Frame): void {
+  send(msg: Message): void {
     if (this.closed) {
       throw new ConnectionClosedError();
     }
-    const data = this.opts.codec.encode(frame);
+    const data = this.opts.codec.encode(msg);
     if (!this.sendBuffer.push(data)) {
       throw new SendBufferFullError();
     }
@@ -323,10 +323,10 @@ class WspulseClient implements Client {
       }
 
       try {
-        const frame = this.opts.codec.decode(normalized);
-        this.opts.onMessage(frame);
+        const msg = this.opts.codec.decode(normalized);
+        this.opts.onMessage(msg);
       } catch (err) {
-        console.warn("wspulse/client: decode failed, frame dropped", err);
+        console.warn("wspulse/client: decode failed, message dropped", err);
       }
     };
 
@@ -483,8 +483,8 @@ class WspulseClient implements Client {
   }
 
   /**
-   * Flush all buffered frames to the WebSocket serially with per-write
-   * timeout. On Node.js each frame is sent via `sendOneFrame` so a
+   * Flush all buffered messages to the WebSocket serially with per-write
+   * timeout. On Node.js each message is sent via `sendOneMessage` so a
    * stalled socket is detected within `writeWait`. In browsers `send()`
    * is fire-and-forget (no completion callback) so no deadline applies.
    *
@@ -504,13 +504,13 @@ class WspulseClient implements Client {
           this.sendBuffer.shift();
           continue;
         }
-        const ok = await this.sendOneFrame(encoded);
+        const ok = await this.sendOneMessage(encoded);
         if (!ok) return; // timeout or error — socket is closing
         this.sendBuffer.shift();
       }
     } finally {
       this.draining = false;
-      // If new frames arrived during the flush, schedule another drain.
+      // If new messages arrived during the flush, schedule another drain.
       if (this.sendBuffer.length > 0 && !this.closed) {
         this.startDrain();
       }
@@ -518,7 +518,7 @@ class WspulseClient implements Client {
   }
 
   /**
-   * Send a single frame with write-deadline enforcement.
+   * Send a single message with write-deadline enforcement.
    *
    * On Node.js (`ws` library): uses the callback form of `send()` and
    * races it against a `writeWait` timeout. On timeout the socket is
@@ -528,7 +528,7 @@ class WspulseClient implements Client {
    *
    * @returns `true` if the write completed, `false` if it timed out or errored.
    */
-  private sendOneFrame(data: string | Uint8Array): Promise<boolean> {
+  private sendOneMessage(data: string | Uint8Array): Promise<boolean> {
     if (this.ws.readyState !== WS_OPEN) return Promise.resolve(false);
     const ws = this.ws;
 
@@ -605,7 +605,7 @@ class WspulseClient implements Client {
     // Stop the drain timer.
     this.stopDrain();
 
-    // Discard unsent frames — close() does not drain the send buffer.
+    // Discard unsent messages — close() does not drain the send buffer.
     this.sendBuffer.clear();
 
     // Close the WebSocket. Suppress errors (may already be closed).

--- a/src/codec.ts
+++ b/src/codec.ts
@@ -1,29 +1,29 @@
-import type { Frame } from "./frame.js";
+import type { Message } from "./message.js";
 
 /**
- * Codec encodes and decodes {@link Frame}s for WebSocket transmission.
+ * Codec encodes and decodes {@link Message}s for WebSocket transmission.
  *
  * Mirrors the `wspulse.Codec` interface from the Go `core` module.
  * Implement this interface to use a custom wire format (e.g. Protocol Buffers).
  *
- * The built-in {@link JSONCodec} is the default and sends JSON text frames.
+ * The built-in {@link JSONCodec} is the default and sends JSON text WebSocket frames.
  */
 export interface Codec {
   /**
-   * Serialize a Frame into data ready to be sent over the WebSocket.
+   * Serialize a Message into data ready to be sent over the WebSocket.
    *
-   * Return a `string` for text frames or `Uint8Array` for binary frames.
-   * The return type must be consistent with {@link binaryType}.
+   * Return a `string` for text WebSocket frames or `Uint8Array` for binary
+   * WebSocket frames. The return type must be consistent with {@link binaryType}.
    */
-  encode(frame: Frame): string | Uint8Array;
+  encode(msg: Message): string | Uint8Array;
 
   /**
-   * Deserialize received WebSocket data into a Frame.
+   * Deserialize received WebSocket data into a Message.
    *
    * `data` is a `string` when `binaryType` is `"text"`, or `Uint8Array`
    * when `binaryType` is `"binary"`.
    */
-  decode(data: string | Uint8Array): Frame;
+  decode(data: string | Uint8Array): Message;
 
   /**
    * The WebSocket frame type this codec uses.
@@ -39,20 +39,20 @@ export interface Codec {
 }
 
 /**
- * Default JSON codec. Frames are encoded as JSON text frames.
+ * Default JSON codec. Messages are encoded as JSON text WebSocket frames.
  *
  * This matches the default `JSONCodec` in the Go `core` module.
  */
 export const JSONCodec: Codec = {
   binaryType: "text",
 
-  encode(frame: Frame): string {
-    return JSON.stringify(frame);
+  encode(msg: Message): string {
+    return JSON.stringify(msg);
   },
 
-  decode(data: string | Uint8Array): Frame {
+  decode(data: string | Uint8Array): Message {
     const str =
       typeof data === "string" ? data : new TextDecoder().decode(data);
-    return JSON.parse(str) as Frame;
+    return JSON.parse(str) as Message;
   },
 };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -39,7 +39,7 @@ export class ConnectionLostError extends Error {
  * Thrown by {@link Client.send} when the internal send buffer is full.
  *
  * The caller should handle this error explicitly — for example by retrying,
- * discarding the frame, or closing the connection.
+ * discarding the message, or closing the connection.
  */
 export class SendBufferFullError extends Error {
   constructor() {

--- a/src/frame.ts
+++ b/src/frame.ts
@@ -1,8 +1,0 @@
-/**
- * The minimal transport unit for the wspulse wire protocol.
- * All fields are optional at the wire layer.
- */
-export interface Frame {
-  event?: string;
-  payload?: unknown;
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export type { Frame } from "./frame.js";
+export type { Message } from "./message.js";
 export type { Client } from "./client.js";
 export type { Transport } from "./transport.js";
 export type { Codec } from "./codec.js";

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,0 +1,8 @@
+/**
+ * The application-layer message type for the wspulse wire protocol.
+ * All fields are optional at the wire layer.
+ */
+export interface Message {
+  event?: string;
+  payload?: unknown;
+}

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,5 +1,5 @@
 import type { Clock } from "./clock.js";
-import type { Frame } from "./frame.js";
+import type { Message } from "./message.js";
 import type { Codec } from "./codec.js";
 import type { Transport } from "./transport.js";
 import { defaultClock } from "./clock.js";
@@ -29,10 +29,10 @@ export interface AutoReconnectOptions {
  */
 export interface ClientOptions {
   /**
-   * Called for every inbound frame decoded by the codec.
+   * Called for every inbound message decoded by the codec.
    * Must not fire after `onDisconnect` has been called.
    */
-  onMessage?: (frame: Frame) => void;
+  onMessage?: (msg: Message) => void;
 
   /**
    * Called exactly once when the client reaches CLOSED state.
@@ -60,10 +60,10 @@ export interface ClientOptions {
   onTransportDrop?: (err: Error | null) => void;
 
   /**
-   * Wire-format codec for encoding/decoding {@link Frame}s.
+   * Wire-format codec for encoding/decoding {@link Message}s.
    *
-   * Defaults to {@link JSONCodec} (JSON text frames). Provide a custom
-   * implementation (e.g. Protocol Buffers) to use binary frames.
+   * Defaults to {@link JSONCodec} (JSON text WebSocket frames). Provide a
+   * custom implementation (e.g. Protocol Buffers) to use binary WebSocket frames.
    */
   codec?: Codec;
   /** Enable exponential backoff reconnection. Disabled by default. */
@@ -83,7 +83,7 @@ export interface ClientOptions {
   dialHeaders?: Record<string, string>;
 
   /**
-   * Maximum number of outbound frames that can be buffered before
+   * Maximum number of outbound messages that can be buffered before
    * {@link Client.send} throws {@link SendBufferFullError}.
    *
    * Must be between 1 and 4096 inclusive. Default: 256.
@@ -115,7 +115,7 @@ const DEFAULT_WRITE_WAIT = 10_000;
 /** @internal Default max inbound message: 1 MiB. */
 const DEFAULT_MAX_MESSAGE_SIZE = 1 << 20;
 
-/** @internal Default send buffer capacity: 256 frames. */
+/** @internal Default send buffer capacity: 256 messages. */
 const DEFAULT_SEND_BUFFER_SIZE = 256;
 
 /** @internal Upper bound for send buffer size. */
@@ -135,7 +135,7 @@ const MAX_RETRIES_LIMIT = 32;
  * Callbacks are no-ops when the caller did not provide them.
  */
 export interface ResolvedOptions {
-  onMessage: (frame: Frame) => void;
+  onMessage: (msg: Message) => void;
   onDisconnect: (err: Error | null) => void;
   onTransportRestore: () => void;
   onTransportDrop: (err: Error | null) => void;

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 import { WebSocketServer } from "ws";
 import { connect } from "../src/client.js";
 import { ConnectionClosedError, SendBufferFullError } from "../src/errors.js";
-import type { Frame } from "../src/frame.js";
+import type { Message } from "../src/message.js";
 import type { Client } from "../src/client.js";
 
 // ── test helpers ────────────────────────────────────────────────────────────────
@@ -12,7 +12,7 @@ function createEchoServer(): { server: WebSocketServer; url: string } {
   const server = new WebSocketServer({ port: 0 });
   server.on("connection", (ws) => {
     ws.on("message", (data, isBinary) => {
-      // Echo back as text frame to match the original JSON string.
+      // Echo back as text WebSocket frame to match the original JSON string.
       ws.send(isBinary ? data : data.toString(), { binary: false });
     });
   });
@@ -52,11 +52,11 @@ describe("client lifecycle", () => {
     const { server, url } = createEchoServer();
     testServer = server;
 
-    const received: Frame[] = [];
+    const received: Message[] = [];
     let disconnectErr: Error | null | undefined;
 
     testClient = await connect(url, {
-      onMessage: (frame) => received.push(frame),
+      onMessage: (msg) => received.push(msg),
       onDisconnect: (err) => {
         disconnectErr = err;
       },
@@ -159,12 +159,12 @@ describe("auto-reconnect", () => {
     testServer = server;
     const port = new URL(url).port;
 
-    const received: Frame[] = [];
+    const received: Message[] = [];
     let transportDropCount = 0;
     let transportRestoreCount = 0;
 
     testClient = await connect(url, {
-      onMessage: (frame) => received.push(frame),
+      onMessage: (msg) => received.push(msg),
       onTransportRestore: () => {
         transportRestoreCount++;
       },
@@ -285,7 +285,7 @@ describe("send buffer overflow", () => {
 
     testClient = await connect(silentUrl);
 
-    // Fill up the 256-frame buffer — should not throw.
+    // Fill up the 256-message buffer — should not throw.
     for (let i = 0; i < 256; i++) {
       testClient.send({ event: "msg", payload: i });
     }
@@ -338,13 +338,13 @@ describe("connect failure with autoReconnect", () => {
 });
 
 describe("multiple messages", () => {
-  it("delivers frames in enqueue order", async () => {
+  it("delivers messages in enqueue order", async () => {
     const { server, url } = createEchoServer();
     testServer = server;
 
-    const received: Frame[] = [];
+    const received: Message[] = [];
     testClient = await connect(url, {
-      onMessage: (frame) => received.push(frame),
+      onMessage: (msg) => received.push(msg),
     });
 
     for (let i = 0; i < 10; i++) {
@@ -381,12 +381,12 @@ describe("maxMessageSize", () => {
     if (typeof addr === "string" || addr === null) throw new Error("bad addr");
     testServer = bigServer;
 
-    const received: Frame[] = [];
+    const received: Message[] = [];
     let disconnectErr: Error | null | undefined;
 
     testClient = await connect(`ws://127.0.0.1:${addr.port}`, {
       maxMessageSize: 100,
-      onMessage: (frame) => received.push(frame),
+      onMessage: (msg) => received.push(msg),
       onDisconnect: (err) => {
         disconnectErr = err;
       },
@@ -402,8 +402,8 @@ describe("maxMessageSize", () => {
 });
 
 describe("decode failure", () => {
-  it("logs warning and continues processing valid frames", async () => {
-    // Server that sends an invalid frame followed by a valid one.
+  it("logs warning and continues processing valid messages", async () => {
+    // Server that sends an invalid message followed by a valid one.
     const server = new WebSocketServer({ port: 0 });
     server.on("connection", (ws) => {
       setTimeout(() => {
@@ -414,15 +414,15 @@ describe("decode failure", () => {
     const addr = server.address();
     if (typeof addr === "string" || addr === null) throw new Error("bad addr");
 
-    const received: Frame[] = [];
+    const received: Message[] = [];
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     testClient = await connect(`ws://127.0.0.1:${addr.port}`, {
-      onMessage: (frame) => received.push(frame),
+      onMessage: (msg) => received.push(msg),
     });
     testServer = server;
 
-    // Wait for the valid frame to arrive.
+    // Wait for the valid message to arrive.
     await vi.waitFor(() => expect(received.length).toBe(1), { timeout: 2000 });
 
     expect(received[0].event).toBe("valid");
@@ -573,7 +573,7 @@ describe("onTransportRestore", () => {
     testServer = server;
     const port = new URL(url).port;
 
-    const received: Frame[] = [];
+    const received: Message[] = [];
     let transportDropCount = 0;
     let transportRestoreCount = 0;
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -584,7 +584,7 @@ describe("onTransportRestore", () => {
     });
 
     testClient = await connect(url, {
-      onMessage: (frame) => received.push(frame),
+      onMessage: (msg) => received.push(msg),
       onTransportDrop: () => {
         transportDropCount++;
       },

--- a/test/codec.test.ts
+++ b/test/codec.test.ts
@@ -1,48 +1,48 @@
 import { describe, it, expect } from "vitest";
 import { JSONCodec } from "../src/codec.js";
 import type { Codec } from "../src/codec.js";
-import type { Frame } from "../src/frame.js";
+import type { Message } from "../src/message.js";
 
 describe("JSONCodec", () => {
-  it("encodes a frame as JSON string", () => {
-    const frame: Frame = { event: "msg", payload: { text: "hello" } };
-    const encoded = JSONCodec.encode(frame);
+  it("encodes a message as JSON string", () => {
+    const msg: Message = { event: "msg", payload: { text: "hello" } };
+    const encoded = JSONCodec.encode(msg);
     expect(typeof encoded).toBe("string");
-    expect(JSON.parse(encoded as string)).toEqual(frame);
+    expect(JSON.parse(encoded as string)).toEqual(msg);
   });
 
-  it("decodes a JSON string into a frame", () => {
+  it("decodes a JSON string into a message", () => {
     const json = '{"event":"msg","payload":{"text":"hello"}}';
-    const frame = JSONCodec.decode(json);
-    expect(frame.event).toBe("msg");
-    expect(frame.payload).toEqual({ text: "hello" });
+    const msg = JSONCodec.decode(json);
+    expect(msg.event).toBe("msg");
+    expect(msg.payload).toEqual({ text: "hello" });
   });
 
-  it("decodes a Uint8Array (UTF-8) into a frame", () => {
+  it("decodes a Uint8Array (UTF-8) into a message", () => {
     const json = '{"event":"test","payload":"binary"}';
     const bytes = new TextEncoder().encode(json);
-    const frame = JSONCodec.decode(bytes);
-    expect(frame.event).toBe("test");
-    expect(frame.payload).toBe("binary");
+    const msg = JSONCodec.decode(bytes);
+    expect(msg.event).toBe("test");
+    expect(msg.payload).toBe("binary");
   });
 
   it("has binaryType 'text'", () => {
     expect(JSONCodec.binaryType).toBe("text");
   });
 
-  it("round-trips a frame", () => {
-    const frame: Frame = { event: "sys", payload: [1, 2, 3] };
-    const decoded = JSONCodec.decode(JSONCodec.encode(frame));
-    expect(decoded).toEqual(frame);
+  it("round-trips a message", () => {
+    const msg: Message = { event: "sys", payload: [1, 2, 3] };
+    const decoded = JSONCodec.decode(JSONCodec.encode(msg));
+    expect(decoded).toEqual(msg);
   });
 
   it("throws on invalid JSON string", () => {
     expect(() => JSONCodec.decode("not json")).toThrow();
   });
 
-  it("encodes a minimal frame (no fields)", () => {
-    const frame: Frame = {};
-    const encoded = JSONCodec.encode(frame);
+  it("encodes a minimal message (no fields)", () => {
+    const msg: Message = {};
+    const encoded = JSONCodec.encode(msg);
     expect(JSON.parse(encoded as string)).toEqual({});
   });
 });
@@ -51,21 +51,21 @@ describe("Codec interface", () => {
   it("accepts a custom binary codec", () => {
     const binaryCodec: Codec = {
       binaryType: "binary",
-      encode(frame: Frame): Uint8Array {
-        return new TextEncoder().encode(JSON.stringify(frame));
+      encode(msg: Message): Uint8Array {
+        return new TextEncoder().encode(JSON.stringify(msg));
       },
-      decode(data: string | Uint8Array): Frame {
+      decode(data: string | Uint8Array): Message {
         const str =
           typeof data === "string" ? data : new TextDecoder().decode(data);
-        return JSON.parse(str) as Frame;
+        return JSON.parse(str) as Message;
       },
     };
 
-    const frame: Frame = { event: "bin", payload: { x: 1 } };
-    const encoded = binaryCodec.encode(frame);
+    const msg: Message = { event: "bin", payload: { x: 1 } };
+    const encoded = binaryCodec.encode(msg);
     expect(encoded).toBeInstanceOf(Uint8Array);
     const decoded = binaryCodec.decode(encoded);
-    expect(decoded).toEqual(frame);
+    expect(decoded).toEqual(msg);
     expect(binaryCodec.binaryType).toBe("binary");
   });
 });

--- a/test/component/basic.test.ts
+++ b/test/component/basic.test.ts
@@ -1,10 +1,10 @@
 /**
- * Component tests — basic connectivity and frame handling.
+ * Component tests — basic connectivity and message handling.
  */
 import { describe, it, expect, afterEach } from "vitest";
 import { connect } from "../../src/client.js";
 import type { Client } from "../../src/client.js";
-import type { Frame } from "../../src/frame.js";
+import type { Message } from "../../src/message.js";
 import { MockTransport, MockDialer } from "./mock-transport.js";
 import { FakeClock } from "./fake-clock.js";
 
@@ -46,15 +46,15 @@ async function connectMock(
 
 describe("component: basic", () => {
   // Scenario 1: Connect -> send -> receive echo -> close clean
-  it("connects, sends a frame, receives echo, and closes cleanly", async () => {
-    const received: Frame[] = [];
+  it("connects, sends a message, receives echo, and closes cleanly", async () => {
+    const received: Message[] = [];
     let disconnectErr: Error | null | undefined;
     let transportDropErr: Error | null | undefined;
     const clock = new FakeClock();
 
     const { client, transport } = await connectMock(clock, {
-      onMessage(frame) {
-        received.push(frame);
+      onMessage(msg) {
+        received.push(msg);
       },
       onDisconnect(err) {
         disconnectErr = err;
@@ -71,9 +71,9 @@ describe("component: basic", () => {
 
     // Verify sent data.
     expect(transport.sent.length).toBe(1);
-    const sentFrame = JSON.parse(transport.sent[0] as string) as Frame;
-    expect(sentFrame.event).toBe("msg");
-    expect(sentFrame.payload).toEqual({ text: "hello" });
+    const sentMessage = JSON.parse(transport.sent[0] as string) as Message;
+    expect(sentMessage.event).toBe("msg");
+    expect(sentMessage.payload).toEqual({ text: "hello" });
 
     // Simulate echo from server.
     transport.injectMessage(transport.sent[0] as string);
@@ -89,18 +89,18 @@ describe("component: basic", () => {
     expect(disconnectErr).toBeNull();
   });
 
-  // Frame field round-trip
-  it("round-trips all Frame fields (event, payload)", async () => {
-    const received: Frame[] = [];
+  // Message field round-trip
+  it("round-trips all Message fields (event, payload)", async () => {
+    const received: Message[] = [];
     const clock = new FakeClock();
 
     const { client, transport } = await connectMock(clock, {
-      onMessage(frame) {
-        received.push(frame);
+      onMessage(msg) {
+        received.push(msg);
       },
     });
 
-    const outbound: Frame = {
+    const outbound: Message = {
       event: "chat.message",
       payload: { user: "alice", text: "hi", n: 42, nested: { ok: true } },
     };
@@ -128,13 +128,13 @@ describe("component: basic", () => {
   });
 
   // Message ordering
-  it("sends multiple frames and receives them in order", async () => {
-    const received: Frame[] = [];
+  it("sends multiple messages and receives them in order", async () => {
+    const received: Message[] = [];
     const clock = new FakeClock();
 
     const { client, transport } = await connectMock(clock, {
-      onMessage(frame) {
-        received.push(frame);
+      onMessage(msg) {
+        received.push(msg);
       },
     });
 

--- a/test/component/misc.test.ts
+++ b/test/component/misc.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { connect } from "../../src/client.js";
 import type { Client } from "../../src/client.js";
-import type { Frame } from "../../src/frame.js";
+import type { Message } from "../../src/message.js";
 import { SendBufferFullError } from "../../src/errors.js";
 import { MockTransport, MockDialer } from "./mock-transport.js";
 import { FakeClock } from "./fake-clock.js";
@@ -66,18 +66,18 @@ describe("component: misc", () => {
       ),
     );
 
-    // Advance past the drain timer (5 ms). The async flush sends frames
-    // serially; each frame needs one microtask tick for the await. FakeClock
+    // Advance past the drain timer (5 ms). The async flush sends messages
+    // serially; each message needs one microtask tick for the await. FakeClock
     // flushes 10 microtasks after the timer fires; yield the remaining ticks
-    // so all 250 frames complete.
+    // so all 250 messages complete.
     await clock.advance(10);
     for (let i = 0; i < total; i++) await Promise.resolve();
 
     expect(transport.sent.length).toBe(total);
 
-    // Verify all frames have the expected event.
+    // Verify all messages have the expected event.
     for (const raw of transport.sent) {
-      const f = JSON.parse(raw as string) as Frame;
+      const f = JSON.parse(raw as string) as Message;
       expect(f.event).toBe("concurrent");
     }
   });
@@ -123,7 +123,7 @@ describe("component: misc", () => {
       t,
     );
 
-    // Send a frame — it goes into the buffer.
+    // Send a message — it goes into the buffer.
     client.send({ event: "ping" });
 
     // Advance past the drain timer (5 ms) so flushSendBuffer fires.
@@ -144,10 +144,10 @@ describe("component: misc", () => {
     void client;
   });
 
-  // Write timeout: unsent frames preserved and re-drained after reconnect
+  // Write timeout: unsent messages preserved and re-drained after reconnect
   it("stalled write preserves buffer across reconnect", async () => {
     const clock = new FakeClock();
-    const received: Frame[] = [];
+    const received: Message[] = [];
     let restoreResolve: () => void = () => {};
     const restored = new Promise<void>((r) => {
       restoreResolve = r;
@@ -162,8 +162,8 @@ describe("component: misc", () => {
     const client = await connect("ws://mock/ws", {
       writeWait: 100,
       autoReconnect: { maxRetries: 3, baseDelay: 10, maxDelay: 50 },
-      onMessage(frame) {
-        received.push(frame);
+      onMessage(msg) {
+        received.push(msg);
       },
       onTransportRestore() {
         restoreResolve();
@@ -173,7 +173,7 @@ describe("component: misc", () => {
     });
     testClient = client;
 
-    // Send two frames — they go into the buffer.
+    // Send two messages — they go into the buffer.
     client.send({ event: "a" });
     client.send({ event: "b" });
 
@@ -185,25 +185,25 @@ describe("component: misc", () => {
     await clock.advance(200);
     await restored;
 
-    // Give the async flush enough microtask ticks to drain the 2 frames
+    // Give the async flush enough microtask ticks to drain the 2 messages
     // on the new transport.
     for (let i = 0; i < 10; i++) await Promise.resolve();
 
-    // Both frames should have been sent on the new transport.
+    // Both messages should have been sent on the new transport.
     expect(t2.sent.length).toBe(2);
-    const f0 = JSON.parse(t2.sent[0] as string) as Frame;
-    const f1 = JSON.parse(t2.sent[1] as string) as Frame;
+    const f0 = JSON.parse(t2.sent[0] as string) as Message;
+    const f1 = JSON.parse(t2.sent[1] as string) as Message;
     expect(f0.event).toBe("a");
     expect(f1.event).toBe("b");
   });
 
-  // close() discards unsent buffered frames (contract: close() does not drain)
-  it("close discards unsent buffered frames", async () => {
+  // close() discards unsent buffered messages (contract: close() does not drain)
+  it("close discards unsent buffered messages", async () => {
     const clock = new FakeClock();
     const t = new MockTransport();
     const { client } = await connectMock(clock, {}, t);
 
-    // Buffer three frames — drain timer (5 ms) has not fired yet.
+    // Buffer three messages — drain timer (5 ms) has not fired yet.
     client.send({ event: "a" });
     client.send({ event: "b" });
     client.send({ event: "c" });
@@ -212,7 +212,7 @@ describe("component: misc", () => {
     client.close();
     await client.done;
 
-    // No frames should have been sent to the transport.
+    // No messages should have been sent to the transport.
     expect(t.sent.length).toBe(0);
   });
 
@@ -239,9 +239,9 @@ describe("component: misc", () => {
     // Advance past drain timer.
     await clock.advance(10);
 
-    // Frame should be sent synchronously (browser path).
+    // Message should be sent synchronously (browser path).
     expect(t.sent.length).toBe(1);
-    const f = JSON.parse(t.sent[0] as string) as Frame;
+    const f = JSON.parse(t.sent[0] as string) as Message;
     expect(f.event).toBe("browser-msg");
   });
 });

--- a/test/component/reconnect.test.ts
+++ b/test/component/reconnect.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { connect } from "../../src/client.js";
 import type { Client } from "../../src/client.js";
-import type { Frame } from "../../src/frame.js";
+import type { Message } from "../../src/message.js";
 import { RetriesExhaustedError } from "../../src/errors.js";
 import { MockTransport, MockDialer } from "./mock-transport.js";
 import { FakeClock } from "./fake-clock.js";
@@ -26,7 +26,7 @@ afterEach(async () => {
 describe("component: reconnect", () => {
   // Scenario 3: Auto-reconnect after transport drop
   it("reconnects after transport drop and resumes sending", async () => {
-    const received: Frame[] = [];
+    const received: Message[] = [];
     let transportRestoreCount = 0;
     let restoredResolve: () => void = () => {};
     const restored = new Promise<void>((r) => {
@@ -39,8 +39,8 @@ describe("component: reconnect", () => {
     const dialer = new MockDialer([t1, t2]);
 
     testClient = await connect("ws://mock/ws", {
-      onMessage(frame) {
-        received.push(frame);
+      onMessage(msg) {
+        received.push(msg);
       },
       onTransportRestore() {
         transportRestoreCount++;

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { resolveOptions } from "../src/options.js";
 import { JSONCodec } from "../src/codec.js";
-import type { Frame } from "../src/frame.js";
+import type { Message } from "../src/message.js";
 
 describe("resolveOptions", () => {
   it("returns defaults when no options provided", () => {
@@ -29,10 +29,10 @@ describe("resolveOptions", () => {
 
   it("default callbacks are callable no-ops", () => {
     const opts = resolveOptions();
-    const frame: Frame = { event: "test" };
+    const msg: Message = { event: "test" };
 
     // These should not throw
-    expect(() => opts.onMessage(frame)).not.toThrow();
+    expect(() => opts.onMessage(msg)).not.toThrow();
     expect(() => opts.onDisconnect(null)).not.toThrow();
     expect(() => opts.onDisconnect(new Error("err"))).not.toThrow();
     expect(() => opts.onTransportRestore()).not.toThrow();
@@ -53,9 +53,9 @@ describe("resolveOptions", () => {
       onTransportDrop,
     });
 
-    const frame: Frame = { event: "msg", payload: "hello" };
-    opts.onMessage(frame);
-    expect(onMessage).toHaveBeenCalledWith(frame);
+    const msg: Message = { event: "msg", payload: "hello" };
+    opts.onMessage(msg);
+    expect(onMessage).toHaveBeenCalledWith(msg);
 
     opts.onDisconnect(null);
     expect(onDisconnect).toHaveBeenCalledWith(null);


### PR DESCRIPTION
## Summary

Rename `Frame` interface to `Message` and `src/frame.ts` to `src/message.ts` across the entire client-ts module. Aligns with upstream `wspulse/core` rename (wspulse/.github#34) — "frame" is reserved for the WebSocket protocol layer (RFC 6455); "message" is the correct term for the application-layer type.

## Related issues

Closes #34
Relates to wspulse/.github#34

## Changes

- Renamed `interface Frame` to `interface Message` in `src/message.ts` (formerly `src/frame.ts`).
- Renamed `src/frame.ts` to `src/message.ts` via `git mv`.
- Updated all import paths from `./frame.js` to `./message.js` in `src/client.ts`, `src/codec.ts`, `src/options.ts`, `src/index.ts`.
- Updated all `Frame` type references to `Message` in source, test, and documentation files.
- Renamed internal method `sendOneFrame` to `sendOneMessage` in `src/client.ts`.
- Updated callback parameter names from `frame` to `msg` in all source and test files.
- Updated JSDoc/comments: "frame" (application-layer) changed to "message"; "WebSocket frame" (RFC 6455 protocol-layer) preserved.
- Updated README.md: Message Format section, API surface table, options table, code examples.
- Updated CHANGELOG.md with `[Unreleased]` breaking change entry.
- Updated AGENTS.md and `.github/copilot-instructions.md` file references.
- Updated `doc/component-tests.md` scenario matrix and additional tests table.
- Updated `src/errors.ts` JSDoc for SendBufferFullError.

## Checklist

### Required

- [x] `make check` passes (format -> lint -> type-check -> test)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional (list only those that apply)

- [x] Breaking change: major version bump discussed in linked issue