### PR TITLE
release: v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- `ServerClosedError` — passed to `onTransportDrop` when the server sends a WebSocket close frame. Exposes `code: number` and `reason: string` read directly from the close frame.
+- `StatusCode` — RFC 6455 §7.4 close status code constants (`NormalClosure`, `GoingAway`, etc.). Exported as a plain number object; custom codes in the `4000`–`4999` private-use range are valid. See [wspulse/.github#37](https://github.com/wspulse/.github/issues/37).
+
 ## [0.6.0] - 2026-04-16
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-02
+
 ### Added
 
 - `ServerClosedError` — passed to `onTransportDrop` when the server sends a WebSocket close frame. Exposes `code: number` and `reason: string` read directly from the close frame.
@@ -148,7 +150,8 @@
 - CI workflow: lint → type-check → test on Node 20 and 22 (3-job matrix)
 - README with quick-start, API reference, and platform notes
 
-[Unreleased]: https://github.com/wspulse/client-ts/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/wspulse/client-ts/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/wspulse/client-ts/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/wspulse/client-ts/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/wspulse/client-ts/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/wspulse/client-ts/compare/v0.5.1...v0.5.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wspulse/client-ts",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wspulse/client-ts",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/ws": "^8.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wspulse/client-ts",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "WebSocket client for wspulse with auto-reconnect and exponential backoff",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/client.ts
+++ b/src/client.ts
@@ -194,11 +194,11 @@ class WspulseClient implements Client {
   private closed = false;
 
   /**
-   * Set by the client immediately before any internal `ws.close(code, reason)`
-   * call that is NOT a server close (e.g. write timeout, write error). The
-   * subsequent `ws.onclose` reads this flag to decide whether to surface a
-   * {@link ServerClosedError} — a self-initiated close must not be reported
-   * as if the server sent the close frame.
+   * Set by the client immediately before internal `ws.close(code, reason)`
+   * calls that still flow through the shared `ws.onclose` handler (currently
+   * the write timeout/write error paths). That handler reads this flag to
+   * decide whether to surface a {@link ServerClosedError} — a self-initiated
+   * close must not be reported as if the server sent the close frame.
    */
   private selfClosing = false;
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -593,7 +593,7 @@ class WspulseClient implements Client {
             this.selfClosing = true;
             ws.close(WS_CLOSE_GOING_AWAY, "write timeout");
           } catch {
-            // Already closed.
+            this.selfClosing = false; // close threw — flag must not persist to next transport.
           }
         }
         resolve(false);
@@ -611,7 +611,7 @@ class WspulseClient implements Client {
                 this.selfClosing = true;
                 ws.close(WS_CLOSE_GOING_AWAY, "write error");
               } catch {
-                // Already closed.
+                this.selfClosing = false; // close threw — flag must not persist to next transport.
               }
             }
             resolve(false);
@@ -631,7 +631,7 @@ class WspulseClient implements Client {
             this.selfClosing = true;
             ws.close(WS_CLOSE_GOING_AWAY, "write error");
           } catch {
-            // Already closed.
+            this.selfClosing = false; // close threw — flag must not persist to next transport.
           }
         }
         resolve(false);

--- a/src/client.ts
+++ b/src/client.ts
@@ -584,11 +584,17 @@ class WspulseClient implements Client {
       const timer = this.clock.setTimeout(() => {
         if (settled) return;
         settled = true;
-        try {
-          this.selfClosing = true;
-          ws.close(WS_CLOSE_GOING_AWAY, "write timeout");
-        } catch {
-          // Already closed.
+        // Guard against stale transport: if a server close + reconnect landed
+        // while this send was in flight, `ws` is no longer the active socket.
+        // Skipping selfClosing mutation avoids suppressing a subsequent
+        // legitimate ServerClosedError on the new transport.
+        if (this.ws === ws) {
+          try {
+            this.selfClosing = true;
+            ws.close(WS_CLOSE_GOING_AWAY, "write timeout");
+          } catch {
+            // Already closed.
+          }
         }
         resolve(false);
       }, this.opts.writeWait);
@@ -600,11 +606,13 @@ class WspulseClient implements Client {
           settled = true;
           this.clock.clearTimeout(timer);
           if (err) {
-            try {
-              this.selfClosing = true;
-              ws.close(WS_CLOSE_GOING_AWAY, "write error");
-            } catch {
-              // Already closed.
+            if (this.ws === ws) {
+              try {
+                this.selfClosing = true;
+                ws.close(WS_CLOSE_GOING_AWAY, "write error");
+              } catch {
+                // Already closed.
+              }
             }
             resolve(false);
           } else {
@@ -618,11 +626,13 @@ class WspulseClient implements Client {
         if (settled) return;
         settled = true;
         this.clock.clearTimeout(timer);
-        try {
-          this.selfClosing = true;
-          ws.close(WS_CLOSE_GOING_AWAY, "write error");
-        } catch {
-          // Already closed.
+        if (this.ws === ws) {
+          try {
+            this.selfClosing = true;
+            ws.close(WS_CLOSE_GOING_AWAY, "write error");
+          } catch {
+            // Already closed.
+          }
         }
         resolve(false);
       }

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,6 +9,7 @@ import {
   RetriesExhaustedError,
   ConnectionLostError,
   SendBufferFullError,
+  ServerClosedError,
 } from "./errors.js";
 import { backoff } from "./backoff.js";
 
@@ -192,6 +193,15 @@ class WspulseClient implements Client {
   /** Whether the client is permanently closed. */
   private closed = false;
 
+  /**
+   * Set by the client immediately before any internal `ws.close(code, reason)`
+   * call that is NOT a server close (e.g. write timeout, write error). The
+   * subsequent `ws.onclose` reads this flag to decide whether to surface a
+   * {@link ServerClosedError} — a self-initiated close must not be reported
+   * as if the server sent the close frame.
+   */
+  private selfClosing = false;
+
   /** Fires exactly once when the client reaches CLOSED state. */
   private readonly doneResolve: () => void;
 
@@ -330,8 +340,28 @@ class WspulseClient implements Client {
       }
     };
 
-    ws.onclose = () => {
-      this.handleTransportDrop();
+    ws.onclose = (ev) => {
+      // Preserve the close frame code and reason so callers can distinguish
+      // server-initiated closes from abrupt network drops.
+      //
+      // Code 1006 ("abnormal closure") is synthesised by the WebSocket spec
+      // when no close frame was received — treat as an abrupt drop.
+      //
+      // When the client self-closed for an internal error (write timeout,
+      // write error), the browser also fires onclose with that same code
+      // and reason. selfClosing distinguishes these from real server-
+      // initiated closes.
+      let dropErr: Error | undefined;
+      if (this.selfClosing) {
+        // Reset immediately — reconnect will create a fresh socket.
+        this.selfClosing = false;
+        dropErr = undefined;
+      } else if (ev.code === 1006) {
+        dropErr = undefined;
+      } else {
+        dropErr = new ServerClosedError(ev.code, ev.reason);
+      }
+      this.handleTransportDrop(dropErr);
     };
 
     ws.onerror = () => {
@@ -345,12 +375,18 @@ class WspulseClient implements Client {
    *
    * If auto-reconnect is enabled, starts the reconnect loop.
    * Otherwise, transitions to CLOSED immediately.
+   *
+   * @param cause  If the drop was triggered by a server close frame, pass
+   *               the {@link ServerClosedError} so onTransportDrop sees
+   *               the code and reason. Leave undefined for abrupt drops
+   *               (default: a generic "transport closed unexpectedly" error).
    */
-  private handleTransportDrop(): void {
+  private handleTransportDrop(cause?: Error): void {
     if (this.closed) return;
 
     this.stopDrain();
-    const dropErr = new Error("wspulse: transport closed unexpectedly");
+    const dropErr =
+      cause ?? new Error("wspulse: transport closed unexpectedly");
     // Set reconnecting before firing the callback so that a synchronous
     // close() call inside onTransportDrop sees the correct state regardless
     // of whether auto-reconnect is enabled.
@@ -549,6 +585,7 @@ class WspulseClient implements Client {
         if (settled) return;
         settled = true;
         try {
+          this.selfClosing = true;
           ws.close(WS_CLOSE_GOING_AWAY, "write timeout");
         } catch {
           // Already closed.
@@ -564,6 +601,7 @@ class WspulseClient implements Client {
           this.clock.clearTimeout(timer);
           if (err) {
             try {
+              this.selfClosing = true;
               ws.close(WS_CLOSE_GOING_AWAY, "write error");
             } catch {
               // Already closed.
@@ -581,6 +619,7 @@ class WspulseClient implements Client {
         settled = true;
         this.clock.clearTimeout(timer);
         try {
+          this.selfClosing = true;
           ws.close(WS_CLOSE_GOING_AWAY, "write error");
         } catch {
           // Already closed.

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -47,3 +47,33 @@ export class SendBufferFullError extends Error {
     this.name = "SendBufferFullError";
   }
 }
+
+/**
+ * Passed to {@link ClientOptions.onTransportDrop} when the server initiates
+ * a WebSocket close handshake by sending a close frame. The `code` and
+ * `reason` fields are taken directly from the close frame.
+ *
+ * This is a protocol-level intentional close, distinct from an abrupt
+ * network drop (which surfaces as a generic `Error`).
+ *
+ * @example
+ * ```ts
+ * onTransportDrop(err) {
+ *   if (err instanceof ServerClosedError) {
+ *     console.log(`server closed: code=${err.code} reason=${err.reason}`);
+ *   }
+ * }
+ * ```
+ */
+export class ServerClosedError extends Error {
+  readonly code: number;
+  readonly reason: string;
+
+  constructor(code: number, reason: string) {
+    const suffix = reason === "" ? "" : `, reason=${JSON.stringify(reason)}`;
+    super(`wspulse: server closed connection: code=${code}${suffix}`);
+    this.name = "ServerClosedError";
+    this.code = code;
+    this.reason = reason;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,11 @@ export { JSONCodec } from "./codec.js";
 export type { ClientOptions, AutoReconnectOptions } from "./options.js";
 export { connect } from "./client.js";
 export { backoff } from "./backoff.js";
+export { StatusCode } from "./status.js";
 export {
   ConnectionClosedError,
   RetriesExhaustedError,
   ConnectionLostError,
   SendBufferFullError,
+  ServerClosedError,
 } from "./errors.js";

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,0 +1,52 @@
+/**
+ * WebSocket close status codes as defined by RFC 6455 §7.4.
+ *
+ * `StatusCode` is a plain number — it is not an exhaustive enum. The
+ * private-use range `4000`–`4999` is reserved by RFC 6455 for application
+ * definitions, so values outside this object are valid.
+ *
+ * Numeric values are identical across all wspulse SDKs.
+ */
+export type StatusCode = number;
+
+// Use an object with `as const` so the values are both readable as
+// `StatusCode.GoingAway` and usable wherever a `number` is expected.
+export const StatusCode = {
+  /** Normal, intentional close (1000). */
+  NormalClosure: 1000,
+
+  /** Endpoint is going away — server shutting down or browser tab closing (1001). */
+  GoingAway: 1001,
+
+  /** Protocol error (1002). */
+  ProtocolError: 1002,
+
+  /** Endpoint received a frame type it cannot accept (1003). */
+  UnsupportedData: 1003,
+
+  /** Received data not consistent with the message type (1007). */
+  InvalidFramePayloadData: 1007,
+
+  /** Endpoint policy violation (1008). */
+  PolicyViolation: 1008,
+
+  /** Message too large to process (1009). */
+  MessageTooBig: 1009,
+
+  /** Client expected a required extension the server did not return (1010). */
+  MandatoryExtension: 1010,
+
+  /** Server encountered an unexpected condition (1011). */
+  InternalError: 1011,
+
+  // --- Local-only sentinels (MUST NOT be sent on the wire, per RFC 6455 §7.4.1) ---
+
+  /** No status code was present in the close frame (1005, local-only). */
+  NoStatusReceived: 1005,
+
+  /** Connection closed abnormally without a close frame (1006, local-only). */
+  AbnormalClosure: 1006,
+
+  /** TLS handshake failure (1015, local-only). */
+  TLSHandshake: 1015,
+} as const;

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,5 +1,5 @@
 /**
- * WebSocket close status codes as defined by RFC 6455 §7.4.
+ * Selected WebSocket close status codes from RFC 6455 §7.4.
  *
  * `StatusCode` is a plain number — it is not an exhaustive enum. The
  * private-use range `4000`–`4999` is reserved by RFC 6455 for application

--- a/test/component/callback.test.ts
+++ b/test/component/callback.test.ts
@@ -4,7 +4,8 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { connect } from "../../src/client.js";
 import type { Client } from "../../src/client.js";
-import { ConnectionLostError } from "../../src/errors.js";
+import { ConnectionLostError, ServerClosedError } from "../../src/errors.js";
+import { StatusCode } from "../../src/status.js";
 import { MockTransport, MockDialer } from "./mock-transport.js";
 import { FakeClock } from "./fake-clock.js";
 
@@ -65,6 +66,25 @@ describe("component: callbacks", () => {
 
     expect(transportDropErr).toBeInstanceOf(Error);
     expect(disconnectErr).toBeInstanceOf(ConnectionLostError);
+  });
+
+  // Scenario 2b: Server close frame with code+reason -> ServerClosedError
+  it("server close frame delivers ServerClosedError with code and reason", async () => {
+    let transportDropErr: Error | null | undefined;
+    const clock = new FakeClock();
+
+    const { transport } = await connectMock(clock, {
+      onTransportDrop(err) {
+        transportDropErr = err;
+      },
+    });
+
+    transport.injectClose(StatusCode.GoingAway, "server shutting down");
+
+    expect(transportDropErr).toBeInstanceOf(ServerClosedError);
+    const sce = transportDropErr as ServerClosedError;
+    expect(sce.code).toBe(StatusCode.GoingAway);
+    expect(sce.reason).toBe("server shutting down");
   });
 
   // onDisconnect fires exactly once on close

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -4,7 +4,9 @@ import {
   RetriesExhaustedError,
   ConnectionLostError,
   SendBufferFullError,
+  ServerClosedError,
 } from "../src/errors.js";
+import { StatusCode } from "../src/status.js";
 
 describe("error classes", () => {
   it("ConnectionClosedError has correct name and message", () => {
@@ -37,5 +39,26 @@ describe("error classes", () => {
     expect(err).toBeInstanceOf(SendBufferFullError);
     expect(err.name).toBe("SendBufferFullError");
     expect(err.message).toContain("buffer");
+  });
+
+  it("ServerClosedError carries code and reason", () => {
+    const err = new ServerClosedError(
+      StatusCode.GoingAway,
+      "server shutting down",
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(ServerClosedError);
+    expect(err.name).toBe("ServerClosedError");
+    expect(err.code).toBe(StatusCode.GoingAway);
+    expect(err.reason).toBe("server shutting down");
+    expect(err.message).toContain("1001");
+    expect(err.message).toContain("server shutting down");
+  });
+
+  it("ServerClosedError with empty reason omits it from message", () => {
+    const err = new ServerClosedError(StatusCode.NormalClosure, "");
+    expect(err.code).toBe(StatusCode.NormalClosure);
+    expect(err.reason).toBe("");
+    expect(err.message).toContain("1000");
   });
 });

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -60,5 +60,6 @@ describe("error classes", () => {
     expect(err.code).toBe(StatusCode.NormalClosure);
     expect(err.reason).toBe("");
     expect(err.message).toContain("1000");
+    expect(err.message).not.toContain("reason=");
   });
 });


### PR DESCRIPTION
## Summary

Release v0.8.0 — preserve server close frame code and reason in `ServerClosedError`.

## Related issues

Closes #37

## Changes

- **BREAKING**: Add `ServerClosedError` class (with `code: number` and `reason: string`) passed to `onTransportDrop` when the server sends a WebSocket close frame
- Add `StatusCode` object with RFC 6455 §7.4 close status code constants
- Export both `ServerClosedError` and `StatusCode` from the package index
- Update `callback.test.ts` to assert close code and reason are preserved
- Add `errors.test.ts` for direct `ServerClosedError` behaviour coverage
- Promote `[Unreleased]` to `[0.8.0] - 2026-05-02` in CHANGELOG
- Update comparison links

## Checklist

### Required

- [x] `make check` passes (`fmt` → `lint` → `test`)
- [x] Each commit represents exactly one logical change
- [x] Commit messages follow the format in `commit-message-instructions.md`
- [x] No unrelated code reformatting in this PR

### Conditional

- [x] Breaking change: this is a v0.x project; breaking changes in minor releases are documented with `**BREAKING**` in CHANGELOG per project convention